### PR TITLE
SMS-Auth: mark token field as autocomplete=one-time-code

### DIFF
--- a/sms-authenticator/src/main/resources/theme-resources/templates/login-sms.ftl
+++ b/sms-authenticator/src/main/resources/theme-resources/templates/login-sms.ftl
@@ -9,7 +9,7 @@
 					<label for="code" class="${properties.kcLabelClass!}">${msg("smsAuthLabel")}</label>
 				</div>
 				<div class="${properties.kcInputWrapperClass!}">
-					<input type="number" id="code" name="code" class="${properties.kcInputClass!}" autocomplete="off" autofocus />
+					<input type="number" id="code" name="code" class="${properties.kcInputClass!}" autocomplete="one-time-code" autofocus />
 				</div>
 			</div>
 			<div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">


### PR DESCRIPTION
according to the apple docs, the input should be marked as autocomplete=one-time-code

See: https://developer.apple.com/documentation/security/one-time_codes/enabling_autofill_for_domain-bound_sms_codes#4277752