### PR TITLE
SMS-Auth: change code input type from number to tel

### DIFF
--- a/sms-authenticator/src/main/resources/theme-resources/templates/login-sms.ftl
+++ b/sms-authenticator/src/main/resources/theme-resources/templates/login-sms.ftl
@@ -9,7 +9,7 @@
 					<label for="code" class="${properties.kcLabelClass!}">${msg("smsAuthLabel")}</label>
 				</div>
 				<div class="${properties.kcInputWrapperClass!}">
-					<input type="number" id="code" name="code" class="${properties.kcInputClass!}" autocomplete="off" autofocus />
+					<input type="tel" id="code" name="code" class="${properties.kcInputClass!}" autocomplete="off" autofocus />
 				</div>
 			</div>
 			<div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">


### PR DESCRIPTION
because tel formats the input on mobile as number only keyboard (ios/apple) which makes the input for the user way easier