### PR TITLE
sms auth: even better html input types

### DIFF
--- a/sms-authenticator/src/main/resources/theme-resources/templates/login-sms.ftl
+++ b/sms-authenticator/src/main/resources/theme-resources/templates/login-sms.ftl
@@ -9,7 +9,7 @@
 					<label for="code" class="${properties.kcLabelClass!}">${msg("smsAuthLabel")}</label>
 				</div>
 				<div class="${properties.kcInputWrapperClass!}">
-					<input type="tel" id="code" name="code" class="${properties.kcInputClass!}" autocomplete="off" autofocus />
+					<input type="number" min="0" inputmode="numeric" pattern="[0-9]*" id="code" name="code" class="${properties.kcInputClass!}" autocomplete="off" autofocus />
 				</div>
 			</div>
 			<div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">


### PR DESCRIPTION
according to w3c there are several better input type options for the code field then type=tel (type="number" min="0" inputmode="numeric" pattern="[0-9]*")