### PR TITLE
feat: Add country code dropdown for enhanced SMS plugin UX

### DIFF
--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorFactory.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorFactory.java
@@ -98,7 +98,8 @@ public class SmsAuthenticatorFactory implements AuthenticatorFactory {
 			new ProviderConfigProperty("normalizePhoneNumber", "Format phone number", "Normalize the phone number using the E164 standard.", ProviderConfigProperty.BOOLEAN_TYPE, false),
 			new ProviderConfigProperty("numberTypeFilters", "Valid number type filters", "A list of valid number types to filter the input phone number by. Possible values are: FIXED_LINE, MOBILE, "
 				+ " FIXED_LINE_OR_MOBILE, PAGER, TOLL_FREE, PREMIUM_RATE, SHARED_COST, PERSONAL_NUMBER, VOIP, UAN, VOICEMAIL.", ProviderConfigProperty.MULTIVALUED_STRING_TYPE, Collections.emptyList()),
-			new ProviderConfigProperty("forceRetryOnBadFormat", "Ask for new number if checks fail", "Sets an error message and asks the user to re-enter phone number if formatting checks are not successfully passed.", ProviderConfigProperty.BOOLEAN_TYPE, false)
+			new ProviderConfigProperty("forceRetryOnBadFormat", "Ask for new number if checks fail", "Sets an error message and asks the user to re-enter phone number if formatting checks are not successfully passed.", ProviderConfigProperty.BOOLEAN_TYPE, false),
+			new ProviderConfigProperty("countryCodeList", "List of country code", "Sets the list of country code in a select input to display to the user the supported countries. List separated by commas (ex : FR,DE,GB)", ProviderConfigProperty.STRING_TYPE, "")
 		);
 	}
 

--- a/sms-authenticator/src/main/resources/theme-resources/templates/mobile_number_form.ftl
+++ b/sms-authenticator/src/main/resources/theme-resources/templates/mobile_number_form.ftl
@@ -8,7 +8,12 @@
 				<div class="${properties.kcLabelWrapperClass!}">
 					<label for="code" class="${properties.kcLabelClass!}">${msg("smsPhoneNumberLabel")}</label>
 				</div>
+			<#if countryList?has_content>
+				<div class="${properties.kcInputWrapperClass!}" style="display:flex">
+					<#include "select-country.ftl">
+			<#else>
 				<div class="${properties.kcInputWrapperClass!}">
+			</#if>
 					<input type="tel" id="code" pattern="[0-9\+\-\.\ ]" name="mobile_number" class="${properties.kcInputClass!}" placeholder="${mobileInputFieldPlaceholder!}" autofocus />
 				</div>
 			</div>

--- a/sms-authenticator/src/main/resources/theme-resources/templates/select-country.ftl
+++ b/sms-authenticator/src/main/resources/theme-resources/templates/select-country.ftl
@@ -1,0 +1,5 @@
+<select id="country-code-select" name="country_code">
+    <#list countryList as country>
+        <option value="${country.code}">${country.emoji} ${country.name} (${country.code})</option>
+    </#list>
+</select>


### PR DESCRIPTION
Introduce a country code selector with phone prefix display to improve user experience in the SMS plugin.

No changes to the plugin's default behavior without configuration. Support for country list config (e.g., FR,DE,GB) enables a pre-phone-number dropdown. Country names are dynamically translated based on the selected language. No adaptations made to the InvalidNumber section, as testing method is unclear.

Future consideration: Add a boolean flag for full country list display. If the input becomes too wide, render it on the previous line instead.

<img width="550" height="412" alt="screenshot" src="https://github.com/user-attachments/assets/23f51c7b-a0ed-44a1-9f6e-349a8f65cbc9" />


