### PR TITLE
fix(app): Exclude zxing from shading to prevent NoClassDefFoundError

### DIFF
--- a/app-authenticator/pom.xml
+++ b/app-authenticator/pom.xml
@@ -111,6 +111,9 @@
                                 <relocation>
                                     <pattern>com.google</pattern>
                                     <shadedPattern>netzbegruenung.keycloak.app.shaded.com.google</shadedPattern>
+									<excludes>
+										<exclude>com.google.zxing.**</exclude>
+									</excludes>
                                 </relocation>
                                 <relocation>
                                     <pattern>io.opencensus</pattern>


### PR DESCRIPTION
The broad relocation rule for the `com.google` package was incorrectly rewriting references to `com.google.zxing` classes.

Since `com.google.zxing:core` is a 'provided' dependency and not included in the shaded JAR, this caused a `NoClassDefFoundError` at runtime when the application tried to load the non-existent shaded `...shaded.com.google.zxing.WriterException` class.

This commit excludes `com.google.zxing.**` from the relocation to ensure that the code correctly references the `zxing` classes provided by the Keycloak runtime environment.