### PR TITLE
fix(app): skip sending push when device id is null or empty

### DIFF
--- a/app-authenticator/src/main/java/netzbegruenung/keycloak/app/messaging/FcmMessagingService.java
+++ b/app-authenticator/src/main/java/netzbegruenung/keycloak/app/messaging/FcmMessagingService.java
@@ -49,7 +49,7 @@ public class FcmMessagingService implements MessagingService {
 	}
 
 	public void send(String devicePushId, ChallengeDto challenge, KeycloakSession session) {
-		if (devicePushId == null) {
+		if (devicePushId == null || devicePushId.isEmpty()) {
 			logger.warnf("Skip sending firebase notification: missing device push ID user [%s]", challenge.userName());
 			return;
 		}


### PR DESCRIPTION
API for setup actually supports sending key with empty strings