### PR TITLE
Add JitPack support for Maven dependency resolution

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17


### PR DESCRIPTION
## Summary

- Add `jitpack.yml` to configure Java 17 for JitPack builds

## Problem

This project's artifacts are not available as Maven dependencies. Users must clone and build locally to use the plugins. See #338 for discussion.

## Solution

JitPack builds directly from GitHub and serves artifacts as a Maven repository. The only change needed was a `jitpack.yml` file to specify Java 17, since JitPack defaults to Java 8 which is incompatible with the Jakarta EE dependencies used by this project.

### Verified on fork

Build succeeded: https://jitpack.io/#alicanalbayrak/keycloak-mfa-plugins

Once merged, consumers can add the dependency as:

  ```xml
  <repositories>
      <repository>
          <id>jitpack.io</id>
          <url>https://jitpack.io</url>
      </repository>
  </repositories>

  <dependency>
      <groupId>com.github.netzbegruenung.keycloak-mfa-plugins</groupId>
      <artifactId>sms-authenticator</artifactId>
      <version>v26.5.3</version>
  </dependency>
```