### PR TITLE
Fix: use consistent parameter naming for device push id

### DIFF
--- a/app-authenticator/README.md
+++ b/app-authenticator/README.md
@@ -150,7 +150,7 @@ The signature is not used for authentication here but rather for a **consistency
 | `device_os`                 | query | The platform on which the authenticator app is running on. Supported values are: `android` and `ios`                                                 |
 | `public_key`                | query | The X.509 public key (e.g. as PKCS#8 base64 encoded) used to verify signatures                                                                       |
 | `key_algorithm`             | query | Key algorithm of the public key                                                                                                                      |
-| `device_push_id (optional)` | query | The platform specific ID to receive push notifications. For android this is the Firebase ID                                                          |
+| `device_push_id (optional)` | query | The platform specific ID to receive push notifications. For android this is the Firebase Registration Token                                                          |
 
 ##### Responses
 
@@ -322,7 +322,7 @@ PUT /realms/{realmId}/credential/registration-token
 
 | Name             | In   | Description                                                                                                  |
 | ---------------- | ---- | ------------------------------------------------------------------------------------------------------------ |
-| `token` | body | The Firebase registration token for push notifications. Can be `null` to unset. |
+| `devicePushId`   | body | The device push ID for push notifications (e.g. Firebase registration token). Can be `null` to unset. |
 
 ##### Responses
 

--- a/app-authenticator/src/main/java/netzbegruenung/keycloak/app/dto/TokenDto.java
+++ b/app-authenticator/src/main/java/netzbegruenung/keycloak/app/dto/TokenDto.java
@@ -1,3 +1,0 @@
-package netzbegruenung.keycloak.app.dto;
-
-public record TokenDto(String token) {}

--- a/app-authenticator/src/main/java/netzbegruenung/keycloak/app/dto/UpdateAppCredentialsDto.java
+++ b/app-authenticator/src/main/java/netzbegruenung/keycloak/app/dto/UpdateAppCredentialsDto.java
@@ -1,0 +1,3 @@
+package netzbegruenung.keycloak.app.dto;
+
+public record UpdateAppCredentialsDto(String devicePushId) {}

--- a/app-authenticator/src/main/java/netzbegruenung/keycloak/app/dto/UpdateDevicePushIdDto.java
+++ b/app-authenticator/src/main/java/netzbegruenung/keycloak/app/dto/UpdateDevicePushIdDto.java
@@ -1,0 +1,3 @@
+package netzbegruenung.keycloak.app.dto;
+
+public record UpdateDevicePushIdDto(String devicePushId) {}

--- a/app-authenticator/src/main/java/netzbegruenung/keycloak/app/dto/UpdateDevicePushIdDto.java
+++ b/app-authenticator/src/main/java/netzbegruenung/keycloak/app/dto/UpdateDevicePushIdDto.java
@@ -1,3 +1,0 @@
-package netzbegruenung.keycloak.app.dto;
-
-public record UpdateDevicePushIdDto(String devicePushId) {}

--- a/app-authenticator/src/main/java/netzbegruenung/keycloak/app/rest/CredentialResourceProvider.java
+++ b/app-authenticator/src/main/java/netzbegruenung/keycloak/app/rest/CredentialResourceProvider.java
@@ -5,7 +5,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import netzbegruenung.keycloak.app.AuthenticationUtil;
 import netzbegruenung.keycloak.app.credentials.AppCredentialModel;
-import netzbegruenung.keycloak.app.dto.UpdateDevicePushIdDto;
+import netzbegruenung.keycloak.app.dto.UpdateAppCredentialsDto;
 import org.jboss.logging.Logger;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.UserModel;
@@ -32,10 +32,10 @@ public class CredentialResourceProvider implements RealmResourceProvider {
 	}
 
 	@PUT
-	@Path("registration-token")
+	@Path("{authenticator_id}/credentials")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	public Response updateRegistrationToken(@HeaderParam(AuthenticationUtil.SIGNATURE_HEADER) List<String> signatureHeader, UpdateDevicePushIdDto dto) {
+	public Response updateRegistrationToken(@HeaderParam(AuthenticationUtil.SIGNATURE_HEADER) List<String> signatureHeader, UpdateAppCredentialsDto dto) {
 		Map<String, String> signatureMap = AuthenticationUtil.getSignatureMap(signatureHeader);
 		if (signatureMap == null) {
 			return Response

--- a/app-authenticator/src/main/java/netzbegruenung/keycloak/app/rest/CredentialResourceProvider.java
+++ b/app-authenticator/src/main/java/netzbegruenung/keycloak/app/rest/CredentialResourceProvider.java
@@ -5,7 +5,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import netzbegruenung.keycloak.app.AuthenticationUtil;
 import netzbegruenung.keycloak.app.credentials.AppCredentialModel;
-import netzbegruenung.keycloak.app.dto.TokenDto;
+import netzbegruenung.keycloak.app.dto.UpdateDevicePushIdDto;
 import org.jboss.logging.Logger;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.UserModel;
@@ -35,7 +35,7 @@ public class CredentialResourceProvider implements RealmResourceProvider {
 	@Path("registration-token")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	public Response updateRegistrationToken(@HeaderParam(AuthenticationUtil.SIGNATURE_HEADER) List<String> signatureHeader, TokenDto tokenDto) {
+	public Response updateRegistrationToken(@HeaderParam(AuthenticationUtil.SIGNATURE_HEADER) List<String> signatureHeader, UpdateDevicePushIdDto dto) {
 		Map<String, String> signatureMap = AuthenticationUtil.getSignatureMap(signatureHeader);
 		if (signatureMap == null) {
 			return Response
@@ -45,10 +45,10 @@ public class CredentialResourceProvider implements RealmResourceProvider {
 		}
 
 		String deviceId = signatureMap.get("keyId");
-		if (tokenDto == null || tokenDto.token() == null || tokenDto.token().isBlank()) {
+		if (dto == null || dto.devicePushId() == null || dto.devicePushId().isBlank()) {
 			return Response
 				.status(Response.Status.BAD_REQUEST)
-				.entity(new Message("invalid_request", "Missing token in request body"))
+				.entity(new Message("invalid_request", "Missing devicePushId in request body"))
 				.build();
 		}
 
@@ -62,7 +62,7 @@ public class CredentialResourceProvider implements RealmResourceProvider {
 
 			// Update the push token
 			AppCredentialModel appCredential = verifiedCredentialContainer.appCredential();
-			appCredential.updateDevicePushId(tokenDto.token());
+			appCredential.updateDevicePushId(dto.devicePushId());
 			UserModel user = verifiedCredentialContainer.user();
 			user.credentialManager().updateStoredCredential(appCredential);
 

--- a/app-authenticator/src/main/java/netzbegruenung/keycloak/app/rest/CredentialResourceProviderFactory.java
+++ b/app-authenticator/src/main/java/netzbegruenung/keycloak/app/rest/CredentialResourceProviderFactory.java
@@ -7,7 +7,7 @@ import org.keycloak.services.resource.RealmResourceProvider;
 import org.keycloak.services.resource.RealmResourceProviderFactory;
 
 public class CredentialResourceProviderFactory implements RealmResourceProviderFactory {
-    public static final String PROVIDER_ID = "credential";
+    public static final String PROVIDER_ID = "app-authenticators";
 
     @Override
     public RealmResourceProvider create(KeycloakSession session) {


### PR DESCRIPTION
On the setup endpoint the parameter is named `device_push_id` but on the `Update Device Push Id` endpoint the parameter is called `token`.

This is a breaking change in the API, but it should be okay since it isn't used in production, yet.