### PR TITLE
Add end-to-end tests for SMS Authenticator, including phone number setup and validation scenarios

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,13 +18,15 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<keycloak.version>26.5.3</keycloak.version>
+		<keycloak.version>26.5.4</keycloak.version>
 		<maven.compiler.release>17</maven.compiler.release>
 		<maven.compiler.version>3.15.0</maven.compiler.version>
 		<maven.shade.version>3.6.1</maven.shade.version>
 		<maven.surefire.version>3.5.4</maven.surefire.version>
 		<!-- keep in sync with the version used by keycloak -->
 		<quarkus.version>3.27.0</quarkus.version>
+		<playwright.version>1.58.0</playwright.version>
+		<jacoco.version>0.8.14</jacoco.version>
 	</properties>
 
 	<dependencyManagement>
@@ -58,6 +60,15 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>${maven.surefire.version}</version>
+					<configuration>
+						<classpathDependencyExcludes>
+							<classpathDependencyExclude>org.jboss.slf4j:slf4j-jboss-logmanager</classpathDependencyExclude>
+						</classpathDependencyExcludes>
+						<systemPropertyVariables>
+							<keycloak.version>${keycloak.version}</keycloak.version>
+							<playwright.version>${playwright.version}</playwright.version>
+						</systemPropertyVariables>
+					</configuration>
 				</plugin>
 
 				<plugin>

--- a/sms-authenticator/pom.xml
+++ b/sms-authenticator/pom.xml
@@ -48,6 +48,67 @@
 			<artifactId>libphonenumber</artifactId>
 			<version>9.0.23</version>
 		</dependency>
+		<dependency>
+			<groupId>com.github.dasniko</groupId>
+			<artifactId>testcontainers-keycloak</artifactId>
+			<version>4.1.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>1.20.4</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.rest-assured</groupId>
+			<artifactId>rest-assured</artifactId>
+			<version>5.5.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.11.3</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.shrinkwrap.resolver</groupId>
+			<artifactId>shrinkwrap-resolver-impl-maven-archive</artifactId>
+			<version>3.3.3</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-admin-client</artifactId>
+			<version>26.0.8</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.microsoft.playwright</groupId>
+			<artifactId>playwright</artifactId>
+			<version>${playwright.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers-mockserver</artifactId>
+			<version>2.0.4</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mock-server</groupId>
+			<artifactId>mockserver-client-java</artifactId>
+			<version>5.15.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jacoco</groupId>
+			<artifactId>org.jacoco.agent</artifactId>
+			<version>${jacoco.version}</version>
+			<classifier>runtime</classifier>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
 
     <build>
@@ -84,6 +145,62 @@
 									</excludes>
 								</filter>
 							</filters>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+				<!--   copy the jacoco agent to target build  -->
+			<plugin>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>copy-jacoco</id>
+						<goals>
+							<goal>copy-dependencies</goal>
+						</goals>
+						<phase>compile</phase>
+						<configuration>
+							<includeArtifactIds>org.jacoco.agent</includeArtifactIds>
+							<includeClassifiers>runtime</includeClassifiers>
+							<outputDirectory>${project.build.directory}/jacoco-agent</outputDirectory>
+							<stripVersion>true</stripVersion>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!--   set up jacoco plugin to generate report  -->
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>${jacoco.version}</version>
+				<executions>
+					<execution>
+						<id>merge</id>
+						<phase>test</phase>
+						<goals>
+							<goal>merge</goal>
+						</goals>
+						<configuration>
+							<fileSets>
+								<fileSet>
+									<directory>${project.build.directory}/jacoco-report/</directory>
+									<includes>
+										<include>*.exec</include>
+									</includes>
+								</fileSet>
+							</fileSets>
+							<destFile>${project.build.directory}/jacoco-report/jacoco-all.exec</destFile>
+						</configuration>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+						<configuration>
+							<dataFile>${project.build.directory}/jacoco-report/jacoco-all.exec</dataFile>
 						</configuration>
 					</execution>
 				</executions>

--- a/sms-authenticator/src/test/java/netzbegruenung/keycloak/ArrayUtils.java
+++ b/sms-authenticator/src/test/java/netzbegruenung/keycloak/ArrayUtils.java
@@ -1,0 +1,8 @@
+package netzbegruenung.keycloak;
+
+public class ArrayUtils {
+
+	public static <T> T getLast(T[] array) {
+		return array[array.length - 1];
+	}
+}

--- a/sms-authenticator/src/test/java/netzbegruenung/keycloak/JbossLogConsumer.java
+++ b/sms-authenticator/src/test/java/netzbegruenung/keycloak/JbossLogConsumer.java
@@ -1,0 +1,37 @@
+package netzbegruenung.keycloak;
+
+import org.jboss.logging.Logger;
+import org.testcontainers.containers.output.OutputFrame;
+
+import java.util.function.Consumer;
+
+public class JbossLogConsumer implements Consumer<OutputFrame> {
+	private final Logger log;
+	private final String prefix;
+
+	public JbossLogConsumer(Logger log) {
+		this.log = log;
+		this.prefix = "";
+	}
+
+	public JbossLogConsumer(Logger log, String prefix) {
+		this.log = log;
+		this.prefix = prefix;
+	}
+
+
+
+	@Override
+	public void accept(OutputFrame frame) {
+		final String message = "[%s] %s".formatted(prefix, frame.getUtf8String().trim());
+		switch (frame.getType()) {
+			case STDOUT -> log.info(message);
+			case STDERR -> log.error(message);
+			default -> log.info(message);
+		}
+	}
+
+	public Consumer<OutputFrame> withPrefix(String prefix) {
+		return new JbossLogConsumer(log, prefix);
+	}
+}

--- a/sms-authenticator/src/test/java/netzbegruenung/keycloak/KeycloakTestContainer.java
+++ b/sms-authenticator/src/test/java/netzbegruenung/keycloak/KeycloakTestContainer.java
@@ -1,0 +1,96 @@
+package netzbegruenung.keycloak;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.testcontainers.containers.Network;
+import org.testcontainers.images.PullPolicy;
+import org.testcontainers.utility.MountableFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class KeycloakTestContainer extends KeycloakContainer {
+
+	private static final Logger log = Logger.getLogger(KeycloakTestContainer.class);
+
+	public static final String KEYCLOAK_IMAGE =
+		String.format("quay.io/keycloak/keycloak:%s", System.getProperty("keycloak.version", "26.5.4"));
+
+
+	static final String[] deps = {
+		"org.wildfly.client:wildfly-client-config",
+		"org.jboss.resteasy:resteasy-client",
+		"org.jboss.resteasy:resteasy-client-api",
+		"org.keycloak:keycloak-admin-client",
+		"com.googlecode.libphonenumber:libphonenumber"
+	};
+
+	static List<File> getDeps() {
+		List<File> dependencies = new ArrayList<File>();
+		for (String dep : deps) {
+			dependencies.addAll(getDep(dep));
+		}
+		return dependencies;
+	}
+
+	static List<File> getDep(String pkg) {
+		return Maven.resolver()
+			.loadPomFromFile("./pom.xml")
+			.resolve(pkg)
+			.withoutTransitivity()
+			.asList(File.class);
+	}
+
+	private KeycloakTestContainer() {
+		super(KEYCLOAK_IMAGE);
+		withImagePullPolicy(PullPolicy.alwaysPull());
+		withReuse(true);
+		withProviderClassesFrom("target/classes");
+		withProviderLibsFrom(getDeps());
+		withLogConsumer(new JbossLogConsumer(log).withPrefix("Keycloak"));
+		withAccessToHost(true);
+		if (isJacocoPresent()) {
+			withCopyFileToContainer(
+					MountableFile.forHostPath("target/jacoco-agent/"),
+					"/jacoco-agent"
+				)
+				.withEnv("JAVA_OPTS", "-javaagent:/jacoco-agent/org.jacoco.agent-runtime.jar=destfile=/tmp/jacoco.exec");
+		}
+	}
+
+	public KeycloakTestContainer(Network network) {
+		this();
+		withNetwork(network);
+	}
+
+	private static boolean isJacocoPresent() {
+		return Files.exists(Path.of("target/jacoco-agent/org.jacoco.agent-runtime.jar"));
+	}
+
+	@Override
+	public void stop() {
+		try {
+			String containerId = getContainerId();
+			String containerShortId;
+			if (containerId.length() > 12) {
+				containerShortId = containerId.substring(0, 12);
+			} else {
+				containerShortId = containerId;
+			}
+			getDockerClient().stopContainerCmd(containerId).exec();
+			if (isJacocoPresent()) {
+				Files.createDirectories(Path.of("target", "jacoco-report"));
+				copyFileFromContainer("/tmp/jacoco.exec", "./target/jacoco-report/jacoco-%s.exec".formatted(containerShortId));
+			}
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		} finally {
+			super.stop();
+		}
+	}
+}

--- a/sms-authenticator/src/test/java/netzbegruenung/keycloak/KeycloakTestUtils.java
+++ b/sms-authenticator/src/test/java/netzbegruenung/keycloak/KeycloakTestUtils.java
@@ -1,0 +1,138 @@
+package netzbegruenung.keycloak;
+
+import jakarta.ws.rs.core.Response;
+import org.jetbrains.annotations.UnknownNullability;
+import org.jspecify.annotations.Nullable;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.*;
+
+import java.util.*;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
+
+public interface KeycloakTestUtils {
+
+	Keycloak getKeycloak();
+
+	default RealmResource findRealmByName(String realm) {
+		return getKeycloak()
+			.realms()
+			.realm(realm);
+	}
+
+	default RealmRepresentation createRealm(Consumer<RealmRepresentation> realmRepresentationConsumer) {
+		RealmRepresentation realmRepresentation = new RealmRepresentation();
+		realmRepresentationConsumer.accept(realmRepresentation);
+		return createRealm(realmRepresentation);
+	}
+
+	default RealmRepresentation createRealm(RealmRepresentation realmRepresentation) {
+		getKeycloak().realms().create(realmRepresentation);
+		return findRealmByName(realmRepresentation.getRealm()).toRepresentation();
+	}
+
+	public static UserRepresentation createUser(
+		RealmResource realm,
+		Consumer<UserRepresentation> userRepresentationConsumer,
+		Consumer<CredentialRepresentation> credentialRepresentationConsumer
+	) {
+		UserRepresentation userRepresentation = new UserRepresentation();
+		userRepresentationConsumer.accept(userRepresentation);
+
+		CredentialRepresentation credentialRepresentation = new CredentialRepresentation();
+		credentialRepresentationConsumer.accept(credentialRepresentation);
+		userRepresentation.setCredentials(List.of(credentialRepresentation));
+
+		realm.users().create(userRepresentation);
+
+		return userRepresentation;
+	}
+
+	public static void createOrUpdateExecutionConfig(
+		RealmResource realm,
+		AuthenticationExecutionInfoRepresentation authenticationExecutionInfo,
+		Consumer<AuthenticatorConfigRepresentation> authenticatorConfigConsumer
+	) {
+		var refreshedExecutionInfo = refreshAuthenticationExecutionInfo(realm, authenticationExecutionInfo);
+		var authenticatorConfigId = refreshedExecutionInfo.getAuthenticationConfig();
+		if (authenticatorConfigId == null) {
+			authenticatorConfigId = UUID.randomUUID().toString();
+			final var authenticatorConfig = new AuthenticatorConfigRepresentation();
+			authenticatorConfig.setId(authenticatorConfigId);
+			authenticatorConfig.setAlias(UUID.randomUUID().toString());
+			final var response = realm.flows().newExecutionConfig(refreshedExecutionInfo.getId(), authenticatorConfig);
+			if (response.getStatus() > 299) {
+				throw new RuntimeException("Failed to create execution config: " + response.getStatus() + ", " + response.readEntity(String.class));
+			}
+			assertEquals(201, response.getStatus());
+		}
+		final var authenticatorConfig = realm.flows().getAuthenticatorConfig(authenticatorConfigId);
+		authenticatorConfigConsumer.accept(authenticatorConfig);
+		realm.flows().updateAuthenticatorConfig(authenticatorConfigId, authenticatorConfig);
+	}
+
+	private static AuthenticationExecutionInfoRepresentation refreshAuthenticationExecutionInfo(RealmResource realm, AuthenticationExecutionInfoRepresentation authenticationExecutionInfo) {
+		final var execution = realm.flows().getExecution(authenticationExecutionInfo.getId());
+		final var flow = realm.flows().getFlow(execution.getParentFlow());
+		final var executions = realm.flows().getExecutions(flow.getAlias());
+		final var executionInfo = executions.stream()
+			.filter(exec -> authenticationExecutionInfo.getId().equals(exec.getId()))
+			.findFirst()
+			.orElse(null);
+		return executionInfo;
+	}
+
+	public static AuthenticationFlowRepresentation copyFlow(RealmResource realm, String originalAlias, Map<String, Object> parameters) {
+		Response copiedFlowResponse = realm.flows().copy(originalAlias, parameters);
+		final var location = copiedFlowResponse.getHeaders().getFirst("Location").toString();
+		final var copiedFlowId = location.substring(location.lastIndexOf("/") + 1);
+		final var copiedFlow = realm.flows().getFlow(copiedFlowId);
+		return copiedFlow;
+	}
+
+	public static void registerUnregisteredRequiredActionById(RealmResource realm, String providerId) {
+		final var requiredAction = realm.flows().getUnregisteredRequiredActions().stream().filter(it -> providerId.equals(it.getProviderId())).findFirst().orElseThrow();
+		realm.flows().registerRequiredAction(requiredAction);
+	}
+
+	static AuthenticationExecutionInfoRepresentation addExecution(
+		RealmResource realm,
+		AuthenticationExecutionInfoRepresentation parentExecution,
+		String providerId,
+		Consumer<AuthenticationExecutionInfoRepresentation> executionConsumer
+	) {
+		if (parentExecution.getFlowId() == null) {
+			throw new RuntimeException("Parent execution has no flow id");
+		}
+		var topLevelFlow = findTopLevelFlowByExecution(realm, parentExecution);
+		final var existingExecutionsWithProvider = realm.flows().getExecutions(topLevelFlow.getAlias()).stream().filter(execution -> providerId.equals(execution.getProviderId())).toList();
+		final var flow = realm.flows().getFlow(parentExecution.getFlowId());
+		realm.flows().addExecution(flow.getAlias(), Map.of("provider", providerId));
+		topLevelFlow = findTopLevelFlowByExecution(realm, parentExecution);
+		final var newExecutions = realm.flows().getExecutions(topLevelFlow.getAlias());
+		final var newExecution = newExecutions
+			.stream()
+			.filter(execution -> providerId.equals(execution.getProviderId()))
+			.filter(execution -> !existingExecutionsWithProvider.contains(execution))
+			.findFirst()
+			.orElseThrow();
+		executionConsumer.accept(newExecution);
+		realm.flows().updateExecutions(topLevelFlow.getAlias(), newExecution);
+		return newExecution;
+	}
+
+	private static AuthenticationFlowRepresentation findTopLevelFlowByExecution(RealmResource realm, AuthenticationExecutionInfoRepresentation execution) {
+		final var allTopLevelFlows = realm.flows().getFlows();
+		for (var oneTopLevelFlow : allTopLevelFlows) {
+			final var allExecutionsForFlow = realm.flows().getExecutions(oneTopLevelFlow.getAlias());
+			final var anyMatch = allExecutionsForFlow.stream().filter(it -> Objects.equals(it.getId(), execution.getId())).findAny();
+			if (anyMatch.isPresent()) {
+				return oneTopLevelFlow;
+			}
+		}
+		throw new RuntimeException("Could not find top level flow for execution " + execution.getId());
+	}
+
+}

--- a/sms-authenticator/src/test/java/netzbegruenung/keycloak/PlaywrightContainer.java
+++ b/sms-authenticator/src/test/java/netzbegruenung/keycloak/PlaywrightContainer.java
@@ -1,0 +1,25 @@
+package netzbegruenung.keycloak;
+
+import org.jboss.logging.Logger;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Objects;
+
+public class PlaywrightContainer extends GenericContainer<PlaywrightContainer> {
+
+	private static final Logger log = Logger.getLogger(PlaywrightContainer.class);
+
+	private static final String playwrightVersion = Objects.requireNonNull(System.getProperty("playwright.version"));
+
+	public PlaywrightContainer(Network network) {
+		super(DockerImageName.parse("mcr.microsoft.com/playwright").withTag("v%s".formatted(playwrightVersion)));
+		withNetwork(network);
+		withExposedPorts(3000);
+		withCommand("/bin/sh", "-c", "npx -y playwright@%s run-server --port 3000 --host 0.0.0.0".formatted(playwrightVersion));
+		waitingFor(Wait.forLogMessage(".*Listening on ws://0.0.0.0:3000.*", 1));
+		withLogConsumer(new JbossLogConsumer(log).withPrefix("Playwright"));
+	}
+}

--- a/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/AbstractAuthenticatorTest.java
+++ b/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/AbstractAuthenticatorTest.java
@@ -1,0 +1,136 @@
+package netzbegruenung.keycloak.authenticator;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import netzbegruenung.keycloak.KeycloakTestContainer;
+import netzbegruenung.keycloak.KeycloakTestUtils;
+import netzbegruenung.keycloak.PlaywrightContainer;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.mockserver.client.MockServerClient;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.mockserver.MockServerContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+public abstract class AbstractAuthenticatorTest implements KeycloakTestUtils {
+
+	private static final Logger log = Logger.getLogger(AbstractAuthenticatorTest.class);
+	public static final ObjectMapper MAPPER = new ObjectMapper();
+
+	private List<String> knownRealms;
+
+	@BeforeEach
+	public void setup() {
+		knownRealms = new ArrayList<>();
+	}
+
+	@AfterEach
+	public void cleanupKeycloakInstance() {
+		List.copyOf(knownRealms).forEach(realmName -> {
+			findRealmByName(realmName).remove();
+			knownRealms.remove(realmName);
+		});
+	}
+
+	protected List<String> getKnownRealms() {
+		return List.copyOf(knownRealms);
+	}
+
+	private static Network network = Network.newNetwork();
+
+	public static final KeycloakContainer container = new KeycloakTestContainer(network);
+
+	protected static final GenericContainer<?> playwrightContainer = new PlaywrightContainer(network);
+
+	protected static final MockServerContainer mockServer = new MockServerContainer(DockerImageName.parse("mockserver/mockserver:5.15.0"))
+		.withNetworkAliases("mockserver")
+		.withNetwork(network);
+
+	protected static MockServerClient mockServerClient;
+
+    @BeforeAll
+    static void startContainer() {
+        container.start();
+		playwrightContainer.start();
+		mockServer.start();
+		mockServerClient = new MockServerClient(mockServer.getHost(), mockServer.getServerPort());
+
+		mockServerClient.when(request().withPath("/sms")).respond(response().withStatusCode(200));
+    }
+
+	 @AfterAll
+	 public static void tearDown() {
+		 mockServerClient.reset();
+		 container.stop();
+		 playwrightContainer.stop();
+		 mockServer.stop();
+		 network.close();
+	 }
+
+	 private Keycloak keycloak;
+
+	public Keycloak getKeycloak() {
+		if (keycloak == null) {
+			keycloak = Keycloak.getInstance(container.getAuthServerUrl(), "master", container.getAdminUsername(), container.getAdminPassword(), "admin-cli");
+		}
+		return keycloak;
+	}
+
+	@Override
+	public RealmRepresentation createRealm(RealmRepresentation realmRepresentation) {
+		final var realm = KeycloakTestUtils.super.createRealm(realmRepresentation);
+		knownRealms.add(realmRepresentation.getRealm());
+		return realm;
+	}
+
+	public static Map<String, String> parseFormData(String formData) {
+		Map<String, String> map = new HashMap<>();
+
+		for (String pair : formData.split("&")) {
+			int idx = pair.indexOf("=");
+
+			if (idx > 0) {
+				String key = pair.substring(0, idx);
+				String value = pair.substring(idx + 1);
+
+				// URL decode both key and value
+				key = URLDecoder.decode(key, StandardCharsets.UTF_8);
+				value = URLDecoder.decode(value, StandardCharsets.UTF_8);
+
+				map.put(key, value);
+			}
+		}
+
+		return map;
+	}
+
+	public static String extractCodeFromBody(String body) {
+		Pattern pattern = Pattern.compile("\\b(\\d{6})\\b");
+		Matcher matcher = pattern.matcher(body);
+
+		if (matcher.find()) {
+			return matcher.group(1);
+		}
+
+		throw new IllegalArgumentException("No code found in Body: " + body);
+	}
+
+}

--- a/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/ApiSmsServiceTest.java
+++ b/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/ApiSmsServiceTest.java
@@ -1,0 +1,346 @@
+package netzbegruenung.keycloak.authenticator;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.AuthenticationExecutionInfoRepresentation;
+import org.mockserver.model.HttpRequest;
+
+import java.util.Base64;
+import java.util.UUID;
+
+import static netzbegruenung.keycloak.ArrayUtils.getLast;
+import static netzbegruenung.keycloak.KeycloakTestUtils.createOrUpdateExecutionConfig;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockserver.model.HttpRequest.request;
+
+public class ApiSmsServiceTest extends AbstractAuthenticatorTest {
+
+	/**
+	 * Navigates to the account page, logs in, and waits until the SMS code form is
+	 * displayed — at which point Keycloak has already sent the SMS to MockServer.
+	 */
+	private HttpRequest loginAndCaptureSmsRequest(Page page) {
+		page.navigate(container.getAuthServerUrl() + "/realms/test-realm/account");
+		page.fill("#username", "test@phasetwo.io");
+		page.fill("#password", "test123");
+		page.click("#kc-login");
+		page.locator("#code").waitFor();
+		return getLast(mockServerClient.retrieveRecordedRequests(request().withPath("/sms")));
+	}
+
+	private AuthenticationExecutionInfoRepresentation findSmsExecution(RealmResource realm) {
+		return realm.flows().getExecutions("Browser with SMS 2FA")
+			.stream()
+			.filter(e -> "mobile-number-authenticator".equals(e.getProviderId()))
+			.findFirst()
+			.orElseThrow();
+	}
+
+	@Test
+	@DisplayName("JSON mode sets Content-Type application/json and sends a JSON body")
+	public void jsonModeSendsJsonBody() throws Exception {
+		BaseTest.setupSMSAuthenticatorForUser(this);
+		final var realm = findRealmByName("test-realm");
+
+		createOrUpdateExecutionConfig(realm, findSmsExecution(realm),
+			config -> config.getConfig().put("urlencode", "false"));
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			final var smsRequest = loginAndCaptureSmsRequest(browser.newPage());
+			final var json = MAPPER.readTree(smsRequest.getBody().getValue().toString());
+
+			assertTrue(smsRequest.getFirstHeader("Content-Type").contains("application/json"));
+			assertTrue(json.has("body"));
+			assertTrue(json.has("to"));
+			assertTrue(json.has("sender"));
+		}
+	}
+
+	@Test
+	@DisplayName("apiTokenInHeader sends the raw token as the Authorization header value")
+	public void apiTokenInHeaderSendsRawToken() {
+		BaseTest.setupSMSAuthenticatorForUser(this);
+		final var realm = findRealmByName("test-realm");
+
+		createOrUpdateExecutionConfig(realm, findSmsExecution(realm), config -> {
+			config.getConfig().put("apiTokenInHeader", "true");
+			config.getConfig().put("apitoken", "my-raw-token");
+		});
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			final var smsRequest = loginAndCaptureSmsRequest(browser.newPage());
+			assertEquals("my-raw-token", smsRequest.getFirstHeader("Authorization"));
+		}
+	}
+
+	@Test
+	@DisplayName("Basic auth sends a Base64-encoded Authorization header when apiuser is configured")
+	public void basicAuthSendsEncodedAuthorizationHeader() {
+		BaseTest.setupSMSAuthenticatorForUser(this);
+		final var realm = findRealmByName("test-realm");
+
+		createOrUpdateExecutionConfig(realm, findSmsExecution(realm), config -> {
+			config.getConfig().put("apiTokenInHeader", "false");
+			config.getConfig().put("apiuser", "my-user");
+			config.getConfig().put("apitoken", "my-password");
+		});
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			final var smsRequest = loginAndCaptureSmsRequest(browser.newPage());
+			final var expected = "Basic " + Base64.getEncoder().encodeToString("my-user:my-password".getBytes());
+			assertEquals(expected, smsRequest.getFirstHeader("Authorization"));
+		}
+	}
+
+	@Test
+	@DisplayName("No Authorization header is sent when neither apiTokenInHeader nor apiuser is set")
+	public void noAuthorizationHeaderWhenNeitherOptionIsSet() {
+		BaseTest.setupSMSAuthenticatorForUser(this);
+		final var realm = findRealmByName("test-realm");
+
+		createOrUpdateExecutionConfig(realm, findSmsExecution(realm), config -> {
+			config.getConfig().put("apiTokenInHeader", "false");
+			config.getConfig().put("apiuser", "");
+		});
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			final var smsRequest = loginAndCaptureSmsRequest(browser.newPage());
+			final var authHeader = smsRequest.getFirstHeader("Authorization");
+			assertTrue(authHeader == null || authHeader.isBlank());
+		}
+	}
+
+	@Test
+	@DisplayName("API token appears in JSON body when apitokenattribute is set and apiTokenInHeader is false")
+	public void apiTokenAppearsInJsonBodyWhenApitokenattributeIsSet() throws Exception {
+		BaseTest.setupSMSAuthenticatorForUser(this);
+		final var realm = findRealmByName("test-realm");
+
+		createOrUpdateExecutionConfig(realm, findSmsExecution(realm), config -> {
+			config.getConfig().put("urlencode", "false");
+			config.getConfig().put("apiTokenInHeader", "false");
+			config.getConfig().put("apiuser", "");
+			config.getConfig().put("apitokenattribute", "token");
+			config.getConfig().put("apitoken", "my-secret");
+		});
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			final var smsRequest = loginAndCaptureSmsRequest(browser.newPage());
+			final var json = MAPPER.readTree(smsRequest.getBody().getValue().toString());
+			assertEquals("my-secret", json.get("token").asText());
+		}
+	}
+
+	@Test
+	@DisplayName("UUID field appears in JSON body when useUuid is enabled")
+	public void uuidAppearsInJsonBody() throws Exception {
+		BaseTest.setupSMSAuthenticatorForUser(this);
+		final var realm = findRealmByName("test-realm");
+
+		createOrUpdateExecutionConfig(realm, findSmsExecution(realm), config -> {
+			config.getConfig().put("urlencode", "false");
+			config.getConfig().put("useUuid", "true");
+			config.getConfig().put("uuidAttribute", "msgid");
+		});
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			final var smsRequest = loginAndCaptureSmsRequest(browser.newPage());
+			final var json = MAPPER.readTree(smsRequest.getBody().getValue().toString());
+			assertDoesNotThrow(() -> UUID.fromString(json.get("msgid").asText()));
+		}
+	}
+
+	@Test
+	@DisplayName("UUID field appears in URL-encoded body when useUuid is enabled")
+	public void uuidAppearsInUrlEncodedBody() {
+		BaseTest.setupSMSAuthenticatorForUser(this);
+		final var realm = findRealmByName("test-realm");
+
+		createOrUpdateExecutionConfig(realm, findSmsExecution(realm), config -> {
+			config.getConfig().put("urlencode", "true");
+			config.getConfig().put("useUuid", "true");
+			config.getConfig().put("uuidAttribute", "msgid");
+		});
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			final var smsRequest = loginAndCaptureSmsRequest(browser.newPage());
+			final var params = parseFormData(smsRequest.getBody().getValue().toString());
+			assertDoesNotThrow(() -> UUID.fromString(params.get("msgid")));
+		}
+	}
+
+	@Test
+	@DisplayName("Custom jsonTemplate is used as the entire request body")
+	public void customJsonTemplateIsUsedAsBody() throws Exception {
+		BaseTest.setupSMSAuthenticatorForUser(this);
+		final var realm = findRealmByName("test-realm");
+
+		createOrUpdateExecutionConfig(realm, findSmsExecution(realm), config -> {
+			config.getConfig().put("urlencode", "false");
+			config.getConfig().put("jsonTemplate", "{\"phone\":\"%s\",\"text\":\"%s\"}");
+		});
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			final var smsRequest = loginAndCaptureSmsRequest(browser.newPage());
+			final var json = MAPPER.readTree(smsRequest.getBody().getValue().toString());
+
+			assertTrue(json.has("phone"));
+			assertTrue(json.has("text"));
+			// Template replaces the default body builder — default fields must not appear
+			assertFalse(json.has("sender"));
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// cleanPhoneNumber tests — each stores a differently-formatted number in the
+	// credential and verifies the cleaned value reaches MockServer as the "to" field
+	// -------------------------------------------------------------------------
+
+	/** Extracts the URL-decoded "to" field from the URL-encoded SMS request body. */
+	private String capturedToField(HttpRequest smsRequest) {
+		return parseFormData(smsRequest.getBody().getValue().toString()).get("to");
+	}
+
+	@Test
+	@DisplayName("cleanPhoneNumber: no transformation when countrycode is empty")
+	public void cleanPhoneNumberDoesNothingWithoutCountryCode() {
+		BaseTest.setupSMSAuthenticatorForUser(this);
+		final var realm = findRealmByName("test-realm");
+
+		createOrUpdateExecutionConfig(realm, findSmsExecution(realm),
+			config -> config.getConfig().put("countrycode", ""));
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			assertEquals("+36201234567", capturedToField(loginAndCaptureSmsRequest(browser.newPage())));
+		}
+	}
+
+	@Test
+	@DisplayName("cleanPhoneNumber: 36... is normalised to +36...")
+	public void cleanPhoneNumberAddsPlusPrefixToNumberStartingWithCountryCode() {
+		// Store "36201234567" — missing the leading +
+		BaseTest.setupSMSAuthenticatorForUser(this, "36201234567");
+		final var realm = findRealmByName("test-realm");
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			assertEquals("+36201234567", capturedToField(loginAndCaptureSmsRequest(browser.newPage())));
+		}
+	}
+
+	@Test
+	@DisplayName("cleanPhoneNumber: 0036... is normalised to +36...")
+	public void cleanPhoneNumberReplacesDoubleZeroPrefixWithPlus() {
+		// Store "0036201234567" — international dialling prefix instead of +
+		BaseTest.setupSMSAuthenticatorForUser(this, "0036201234567");
+		final var realm = findRealmByName("test-realm");
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			assertEquals("+36201234567", capturedToField(loginAndCaptureSmsRequest(browser.newPage())));
+		}
+	}
+
+	@Test
+	@DisplayName("cleanPhoneNumber: +360... is normalised to +36... (extra 0 after country code)")
+	public void cleanPhoneNumberRemovesExtraZeroAfterCountryCode() {
+		// Store "+360201234567" — spurious 0 between country code and subscriber number
+		BaseTest.setupSMSAuthenticatorForUser(this, "+360201234567");
+		final var realm = findRealmByName("test-realm");
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			assertEquals("+36201234567", capturedToField(loginAndCaptureSmsRequest(browser.newPage())));
+		}
+	}
+
+	@Test
+	@DisplayName("cleanPhoneNumber: 0... is normalised to +36... (national format with leading 0)")
+	public void cleanPhoneNumberReplacesLeadingZeroWithCountryCode() {
+		// Store "0201234567" — national format, leading 0 should be replaced with +36
+		BaseTest.setupSMSAuthenticatorForUser(this, "0201234567");
+		final var realm = findRealmByName("test-realm");
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			assertEquals("+36201234567", capturedToField(loginAndCaptureSmsRequest(browser.newPage())));
+		}
+	}
+
+	@Test
+	@DisplayName("receiverJsonTemplate formats the receiver phone number value in the JSON body")
+	public void receiverJsonTemplateFormatsPhoneNumber() throws Exception {
+		BaseTest.setupSMSAuthenticatorForUser(this);
+		final var realm = findRealmByName("test-realm");
+
+		createOrUpdateExecutionConfig(realm, findSmsExecution(realm), config -> {
+			config.getConfig().put("urlencode", "false");
+			config.getConfig().put("receiverJsonTemplate", "[\"%s\"]");
+		});
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			final var smsRequest = loginAndCaptureSmsRequest(browser.newPage());
+			final var json = MAPPER.readTree(smsRequest.getBody().getValue().toString());
+
+			// Default template: "to":"<phone>"; custom template: "to":["<phone>"]
+			assertTrue(json.get("to").isArray());
+		}
+	}
+}

--- a/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/BaseTest.java
+++ b/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/BaseTest.java
@@ -1,0 +1,159 @@
+package netzbegruenung.keycloak.authenticator;
+
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.options.AriaRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.*;
+import org.testcontainers.mockserver.MockServerContainer;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import static netzbegruenung.keycloak.ArrayUtils.getLast;
+import static netzbegruenung.keycloak.KeycloakTestUtils.*;
+import static org.mockserver.model.HttpRequest.request;
+
+
+public class BaseTest extends AbstractAuthenticatorTest {
+
+	@Test
+	@DisplayName("Test SMS Mobile number setup for user")
+	public void setupSMSAuthenticatorForUser() {
+		setupSMSAuthenticatorForUser(this);
+	}
+
+	/**
+	 * This method is called from multiple test methods as well to:
+	 *  - set up the realm with the proper flow, required actions, etc
+	 *  - create a test user
+	 *  - setup the SMS based 2FA for the user
+	 *
+	 * The most basic call of this method is in `BaseTest::setupSMSAuthenticatorForUser`.
+	 * All other calls just use this for setup.
+	 * @param testInstance
+	 */
+	public static void setupSMSAuthenticatorForUser(AbstractAuthenticatorTest testInstance) {
+		setupSMSAuthenticatorForUser(testInstance, "+36201234567");
+	}
+
+	public static void setupSMSAuthenticatorForUser(AbstractAuthenticatorTest testInstance, String mobileNumber) {
+		RealmRepresentation testRealm = testInstance.createRealm(realmRepresentation -> {
+			realmRepresentation.setRealm("test-realm");
+			realmRepresentation.setEnabled(true);
+			realmRepresentation.setLoginWithEmailAllowed(true);
+		});
+		RealmResource realm = testInstance.getKeycloak().realm(testRealm.getRealm());
+
+		createUser(
+			realm,
+			userRepresentation -> {
+				userRepresentation.setEnabled(true);
+				userRepresentation.setUsername("test@phasetwo.io");
+				userRepresentation.setEmail("test@phasetwo.io");
+				userRepresentation.setEmailVerified(true);
+				userRepresentation.setFirstName("Test");
+				userRepresentation.setLastName("User");
+			},
+			credentialRepresentation -> {
+				credentialRepresentation.setType(CredentialRepresentation.PASSWORD);
+				credentialRepresentation.setValue("test123");
+				credentialRepresentation.setTemporary(false);
+			}
+		);
+
+		final var copiedFlow = copyFlow(realm, "browser", Map.of("newName", "Browser with SMS 2FA"));
+		var copiedExecutions = realm.flows().getExecutions(copiedFlow.getAlias());
+		final var otpExecution = copiedExecutions.stream().filter(execution -> execution.getDisplayName().contains("Conditional 2FA")).findFirst().orElseThrow();
+
+		final var smsTwoFactorExecution = addExecution(realm, otpExecution, "mobile-number-authenticator", executionInfoRepresentation -> {
+			executionInfoRepresentation.setRequirement("ALTERNATIVE");
+		});
+
+		createOrUpdateExecutionConfig(realm, smsTwoFactorExecution, executionConfig -> {
+			executionConfig.setAlias("sms-2fa");
+			executionConfig.getConfig().putAll(
+				Map.ofEntries(
+					Map.entry("apiurl", "http://mockserver:" + MockServerContainer.PORT + "/sms"),
+					Map.entry("urlencode", "true"),
+					Map.entry("apiTokenInHeader", "false"),
+					Map.entry("apitoken", "secret-api-token"),
+					Map.entry("apiuser", "api-user"),
+					Map.entry("messageattribute", "body"),
+					Map.entry("receiverattribute", "to"),
+					Map.entry("senderattribute", "sender"),
+					Map.entry("senderId", "senderId"),
+					Map.entry("forceSecondFactor", "false"),
+					Map.entry("simulation", "false"),
+					Map.entry("countrycode", "+36"),
+					Map.entry("length", "6"),
+					Map.entry("whitelist", "TODO-test-this"),
+					Map.entry("ttl", "300"),
+					Map.entry("forceRetryOnBadFormat", "false"),
+					Map.entry("normalizePhoneNumber", "false"),
+					Map.entry("hideResponsePayload", "false"),
+					Map.entry("storeInAttribute", "false")
+				));
+		});
+
+		registerUnregisteredRequiredActionById(realm, "mobile_number_config");
+		registerUnregisteredRequiredActionById(realm, "phone_validation_config");
+
+
+		try (final var playwright = Playwright.create(); final var browser = playwright.chromium().connect("ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)), new BrowserType.ConnectOptions().setExposeNetwork("*"));) {
+			Page page = browser.newPage();
+			page.navigate(container.getAuthServerUrl() + "/realms/" + testRealm.getRealm() + "/account");
+
+			page.fill("#username", "test@phasetwo.io");
+			page.fill("#password", "test123");
+			page.click("#kc-login");
+
+			page.getByTestId("page-heading").waitFor();
+			if (!page.getByTestId("accountSecurity").isVisible()) {
+				page.click("#nav-toggle");
+			}
+			page.getByTestId("accountSecurity").click();
+			page.getByTestId("account-security/signing-in").click();
+			page.getByTestId("mobile-number/create").click(new Locator.ClickOptions().setForce(true));
+
+			if (page.getByText("Sign in to your account").isVisible()) {
+				page.fill("#password", "test123");
+				page.locator("input[name='login']").click();
+			}
+			if (page.getByText("Please enter your phone number").isVisible()) {
+				page.fill("#code", mobileNumber);
+				page.locator("input[name='phonenumber']").click();
+			}
+
+			assertThat(page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName("SMS Code"))).isVisible();
+
+			final var sentSmsRequest = getLast(mockServerClient.retrieveRecordedRequests(request().withPath("/sms")));
+			final var smsRequestBody = sentSmsRequest.getBody().getValue().toString();
+			final var smsData = parseFormData(smsRequestBody);
+			final var verificationCode = extractCodeFromBody(smsData.get("body"));
+
+			page.fill("#code", verificationCode);
+			page.locator("input[name='login']").click();
+
+			page.getByTestId("page-heading").waitFor();
+			if (!page.getByTestId("accountSecurity").isVisible()) {
+				page.click("#nav-toggle");
+			}
+			page.getByTestId("accountSecurity").click();
+			page.getByTestId("account-security/signing-in").click();
+			assertThat(page.getByText("Mobile Number: ***567")).isVisible();
+		}
+
+		testRealm.setBrowserFlow(copiedFlow.getAlias());
+		realm.update(testRealm);
+	}
+
+}

--- a/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/PhoneNumberRequiredActionTest.java
+++ b/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/PhoneNumberRequiredActionTest.java
@@ -1,0 +1,479 @@
+package netzbegruenung.keycloak.authenticator;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.testcontainers.mockserver.MockServerContainer;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import static netzbegruenung.keycloak.ArrayUtils.getLast;
+import static netzbegruenung.keycloak.KeycloakTestUtils.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockserver.model.HttpRequest.request;
+
+public class PhoneNumberRequiredActionTest extends AbstractAuthenticatorTest {
+
+	/**
+	 * Creates realm, user, and authentication flow with the mobile-number-authenticator.
+	 * configOverrides are merged on top of sensible defaults. Returns the realm resource.
+	 */
+	private RealmResource setupRealm(Map<String, String> configOverrides) {
+		final var testRealm = createRealm(r -> {
+			r.setRealm("test-realm");
+			r.setEnabled(true);
+			r.setLoginWithEmailAllowed(true);
+		});
+		final var realm = getKeycloak().realm(testRealm.getRealm());
+
+		createUser(
+			realm,
+			u -> {
+				u.setEnabled(true);
+				u.setUsername("test@phasetwo.io");
+				u.setEmail("test@phasetwo.io");
+				u.setEmailVerified(true);
+				u.setFirstName("Test");
+				u.setLastName("User");
+			},
+			c -> {
+				c.setType(CredentialRepresentation.PASSWORD);
+				c.setValue("test123");
+				c.setTemporary(false);
+			}
+		);
+
+		final var copiedFlow = copyFlow(realm, "browser", Map.of("newName", "Browser with SMS 2FA"));
+		final var otpExecution = realm.flows().getExecutions(copiedFlow.getAlias())
+			.stream()
+			.filter(e -> e.getDisplayName().contains("Conditional 2FA"))
+			.findFirst()
+			.orElseThrow();
+
+		final var smsExecution = addExecution(realm, otpExecution, "mobile-number-authenticator",
+			e -> e.setRequirement("ALTERNATIVE"));
+
+		final var config = new HashMap<String, String>();
+		config.put("apiurl", "http://mockserver:" + MockServerContainer.PORT + "/sms");
+		config.put("urlencode", "true");
+		config.put("apiTokenInHeader", "false");
+		config.put("apitoken", "secret-api-token");
+		config.put("apiuser", "api-user");
+		config.put("messageattribute", "body");
+		config.put("receiverattribute", "to");
+		config.put("senderattribute", "sender");
+		config.put("senderId", "senderId");
+		config.put("forceSecondFactor", "false");
+		config.put("simulation", "false");
+		config.put("countrycode", "+36");
+		config.put("length", "6");
+		config.put("ttl", "300");
+		config.put("forceRetryOnBadFormat", "false");
+		config.put("normalizePhoneNumber", "false");
+		config.put("hideResponsePayload", "false");
+		config.put("storeInAttribute", "false");
+		config.putAll(configOverrides);
+
+		createOrUpdateExecutionConfig(realm, smsExecution, executionConfig -> {
+			executionConfig.setAlias("sms-2fa");
+			executionConfig.getConfig().putAll(config);
+		});
+
+		registerUnregisteredRequiredActionById(realm, "mobile_number_config");
+		registerUnregisteredRequiredActionById(realm, "phone_validation_config");
+
+		return realm;
+	}
+
+	/** Navigates to the phone-number setup form via the account console. */
+	private void navigateToPhoneSetupForm(Page page) {
+		page.navigate(container.getAuthServerUrl() + "/realms/test-realm/account");
+		page.fill("#username", "test@phasetwo.io");
+		page.fill("#password", "test123");
+		page.click("#kc-login");
+
+		page.getByTestId("page-heading").waitFor();
+		if (!page.getByTestId("accountSecurity").isVisible()) {
+			page.click("#nav-toggle");
+		}
+		page.getByTestId("accountSecurity").click();
+		page.getByTestId("account-security/signing-in").click();
+		page.getByTestId("mobile-number/create").click(new Locator.ClickOptions().setForce(true));
+
+		if (page.getByText("Sign in to your account").isVisible()) {
+			page.fill("#password", "test123");
+			page.locator("input[name='login']").click();
+		}
+	}
+
+	/** Enters the phone number, captures the resulting SMS code and submits it. */
+	private void submitPhoneAndVerifyCode(Page page, String phoneNumber) {
+		page.fill("#code", phoneNumber);
+		page.locator("input[name='phonenumber']").click();
+
+		final var sentSmsRequest = getLast(mockServerClient.retrieveRecordedRequests(request().withPath("/sms")));
+		final var smsData = parseFormData(sentSmsRequest.getBody().getValue().toString());
+		final var verificationCode = extractCodeFromBody(smsData.get("body"));
+
+		page.fill("#code", verificationCode);
+		page.locator("input[name='login']").click();
+
+		page.getByTestId("page-heading").waitFor();
+	}
+
+	@Test
+	@DisplayName("Phone number is normalised via E164 and stored as a mobile-number credential")
+	public void normalizedPhoneNumberIsSavedAsCredential() throws JsonProcessingException {
+		// normalizePhoneNumber=true exercises formatPhoneNumber(); "+36201234567" is a valid
+		// Hungarian mobile number that comes out of E164 formatting unchanged.
+		final var realm = setupRealm(Map.of("normalizePhoneNumber", "true"));
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			final var page = browser.newPage();
+			navigateToPhoneSetupForm(page);
+			submitPhoneAndVerifyCode(page, "+36201234567");
+		}
+
+		final var userId = realm.users().search("test@phasetwo.io").get(0).getId();
+		final var credentials = realm.users().get(userId).credentials();
+		final var mobileCredential = credentials.stream().filter(c -> "mobile-number".equals(c.getType())).findFirst();
+		assertTrue(
+			mobileCredential.isPresent(),
+			"Expected a mobile-number credential to be stored for the user"
+		);
+		final var credentialData = MAPPER.readTree(mobileCredential.get().getCredentialData());
+		assertEquals("+36201234567", credentialData.get("mobileNumber").asText());
+	}
+
+	@Test
+	@DisplayName("forceSecondFactor=true triggers phone setup as a required action on the next login")
+	public void forceSecondFactorTriggersPhoneSetupOnLogin() throws JsonProcessingException {
+		// evaluateTriggers() checks forceSecondFactor and adds mobile_number_config
+		// to the user's required actions when they have no existing 2FA credential.
+		setupRealm(Map.of("forceSecondFactor", "true"));
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			final var page = browser.newPage();
+			page.navigate(container.getAuthServerUrl() + "/realms/test-realm/account");
+			page.fill("#username", "test@phasetwo.io");
+			page.fill("#password", "test123");
+			page.click("#kc-login");
+
+			// evaluateTriggers fires → mobile_number_config required action added →
+			// phone number form is shown before the user reaches the account console.
+			page.locator("input[name='phonenumber']").waitFor();
+
+			submitPhoneAndVerifyCode(page, "+36201234567");
+		}
+
+		final var realm = findRealmByName("test-realm");
+		final var userId = realm.users().search("test@phasetwo.io").get(0).getId();
+		final var credentials = realm.users().get(userId).credentials();
+		assertTrue(
+			credentials.stream().anyMatch(c -> "mobile-number".equals(c.getType())),
+			"Expected a mobile-number credential after forceSecondFactor triggered phone setup"
+		);
+	}
+
+	@Test
+	@DisplayName("A user who holds the whitelist role is not prompted for phone setup even when forceSecondFactor=true")
+	public void whitelistedUserSkipsPhoneSetupEnforcement() {
+		final var realm = setupRealm(Map.of(
+			"forceSecondFactor", "true",
+			"whitelist", "sms-exempt"
+		));
+
+		// Create the realm role and assign it to the user
+		final var roleRep = new RoleRepresentation();
+		roleRep.setName("sms-exempt");
+		realm.roles().create(roleRep);
+
+		final var userId = realm.users().search("test@phasetwo.io").get(0).getId();
+		final var savedRole = realm.roles().get("sms-exempt").toRepresentation();
+		realm.users().get(userId).roles().realmLevel().add(List.of(savedRole));
+
+		createUser(
+			realm,
+			u -> {
+				u.setEnabled(true);
+				u.setUsername("test-non-whitelisted@phasetwo.io");
+				u.setEmail("test-non-whitelisted@phasetwo.io");
+				u.setEmailVerified(true);
+				u.setFirstName("Test");
+				u.setLastName("User");
+			},
+			c -> {
+				c.setType(CredentialRepresentation.PASSWORD);
+				c.setValue("test123");
+				c.setTemporary(false);
+			}
+		);
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			final var page = browser.newPage();
+			page.navigate(container.getAuthServerUrl() + "/realms/test-realm/account");
+			page.fill("#username", "test@phasetwo.io");
+			page.fill("#password", "test123");
+			page.click("#kc-login");
+
+			// evaluateTriggers sees the whitelist role on the user and returns early —
+			// the phone setup required action must not be added and the user lands
+			// directly on the account console.
+			page.getByTestId("page-heading").waitFor();
+			assertThat(page.locator("input[name='phonenumber']")).not().isVisible();
+		}
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			final var page = browser.newPage();
+			page.navigate(container.getAuthServerUrl() + "/realms/test-realm/account");
+			page.fill("#username", "test-non-whitelisted@phasetwo.io");
+			page.fill("#password", "test123");
+			page.click("#kc-login");
+
+			// evaluateTriggers sees the whitelist role on the user and returns early —
+			// the phone setup required action must be added and the user lands
+			// directly on the phone-number setup page.
+			assertThat(page.locator("input[name='phonenumber']")).isVisible();
+		}
+	}
+
+	@Test
+	@DisplayName("Country code dropdown appears when countryCodeList is set; phone is assembled from country code and local number")
+	public void countryCodeDropdownIsShownAndPhoneCombinedWithLocalNumber() throws JsonProcessingException {
+		// getCountryCodeList() builds the list from countryCodeList config and passes it to the
+		// template. processAction() prepends the selected country_code to the local number.
+		setupRealm(Map.of("countryCodeList", "HU,DE"));
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			final var page = browser.newPage();
+			navigateToPhoneSetupForm(page);
+
+			// The country-code select must be present when countryCodeList is configured
+			assertThat(page.locator("#country-code-select")).isVisible();
+
+			// Select Hungary (+36) and enter only the subscriber number (no country prefix)
+			page.selectOption("#country-code-select", "+36");
+			page.fill("#code", "201234567");
+			page.locator("input[name='phonenumber']").click();
+
+			final var sentSmsRequest = getLast(mockServerClient.retrieveRecordedRequests(request().withPath("/sms")));
+			final var smsData = parseFormData(sentSmsRequest.getBody().getValue().toString());
+			final var verificationCode = extractCodeFromBody(smsData.get("body"));
+
+			page.fill("#code", verificationCode);
+			page.locator("input[name='login']").click();
+
+			page.getByTestId("page-heading").waitFor();
+		}
+
+		final var realm = findRealmByName("test-realm");
+		final var userId = realm.users().search("test@phasetwo.io").get(0).getId();
+		final var credentials = realm.users().get(userId).credentials();
+		final var mobileCredential = credentials.stream()
+			.filter(c -> "mobile-number".equals(c.getType()))
+			.findFirst();
+		assertTrue(mobileCredential.isPresent(), "Expected a mobile-number credential");
+		// processAction: countryCode "+36" + local "201234567" → "+36201234567"
+		final var credentialData = MAPPER.readTree(mobileCredential.get().getCredentialData());
+		assertEquals("+36201234567", credentialData.get("mobileNumber").asText());
+	}
+
+	@Test
+	@DisplayName("forceRetryOnBadFormat=true re-challenges with an error when the phone number cannot be parsed")
+	public void forceRetryOnBadFormatShowsErrorForUnparsablePhoneNumber() {
+		// normalizePhoneNumber=true triggers formatPhoneNumber(). A lone "+" strips to "+"
+		// after the non-digit filter, which causes a NumberParseException. With
+		// forceRetryOnBadFormat=true, handleInvalidNumber() is called and the error
+		// message "numberFormatFailedToParse" is rendered on the form.
+		setupRealm(Map.of(
+			"normalizePhoneNumber", "true",
+			"forceRetryOnBadFormat", "true"
+		));
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			final var page = browser.newPage();
+			navigateToPhoneSetupForm(page);
+
+			// "+" is a single character that satisfies the HTML5 pattern [0-9\+\-\.\ ]
+			// but cannot be parsed as a valid phone number by libphonenumber.
+			page.fill("#code", "+");
+			page.locator("input[name='phonenumber']").click();
+
+			assertThat(page.getByText("Failed to parse the phone number, please enter it again.")).isVisible();
+		}
+	}
+
+	@Test
+	@DisplayName("forceRetryOnBadFormat=true re-challenges with an error when the phone number is parseable but not a valid number")
+	public void forceRetryOnBadFormatShowsErrorForInvalidPhoneNumber() {
+		// "+3620123" passes phoneNumberUtil.parse() (syntactically valid E164) but
+		// fails isValidNumber() because the subscriber part is too short for Hungary.
+		// This exercises the numberFormatNumberInvalid branch, distinct from the
+		// NumberParseException branch tested above.
+		setupRealm(Map.of(
+			"normalizePhoneNumber", "true",
+			"forceRetryOnBadFormat", "true"
+		));
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			final var page = browser.newPage();
+			navigateToPhoneSetupForm(page);
+
+			page.fill("#code", "20123");
+			page.locator("input[name='phonenumber']").click();
+
+			assertThat(page.getByText("Phone number invalid, please enter it again.")).isVisible();
+		}
+	}
+
+	@Test
+	@DisplayName("numberTypeFilters=MOBILE rejects a valid Hungarian landline with a numberFormatNoMatchingFilters error")
+	public void numberTypeFilterRejectsLandlineWhenMobileFilterIsSet() {
+		// +3629123456 is a valid Hungarian FIXED_LINE number — it passes parse() and
+		// isValidNumber(), but getNumberType() returns FIXED_LINE which does not match
+		// the MOBILE filter, triggering the numberFormatNoMatchingFilters error path.
+		// Filters are separated by "##" (Splitter.on("##") in the source).
+		setupRealm(Map.of(
+			"normalizePhoneNumber", "true",
+			"forceRetryOnBadFormat", "true",
+			"numberTypeFilters", "MOBILE"
+		));
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			final var page = browser.newPage();
+			navigateToPhoneSetupForm(page);
+
+			page.fill("#code", "+3629123456");
+			page.locator("input[name='phonenumber']").click();
+
+			assertThat(page.getByText("Phone number format is not allowed. Please use a regular mobile or fixed line number.")).isVisible();
+		}
+	}
+
+	@Test
+	@DisplayName("numberTypeFilters=FIXED_LINE rejects a valid Hungarian mobile number with a numberFormatNoMatchingFilters error")
+	public void numberTypeFilterRejectsLandlineWhenFixedLineFilterIsSet() {
+		// +36201234567 is a valid Hungarian MOBILE number — it passes parse() and
+		// isValidNumber(), but getNumberType() returns FIXED_LINE which does not match
+		// the MOBILE filter, triggering the numberFormatNoMatchingFilters error path.
+		// Filters are separated by "##" (Splitter.on("##") in the source).
+		setupRealm(Map.of(
+			"normalizePhoneNumber", "true",
+			"forceRetryOnBadFormat", "true",
+			"numberTypeFilters", "FIXED_LINE"
+		));
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			final var page = browser.newPage();
+			navigateToPhoneSetupForm(page);
+
+			page.fill("#code", "+36201234567");
+			page.locator("input[name='phonenumber']").click();
+
+			assertThat(page.getByText("Phone number format is not allowed. Please use a regular mobile or fixed line number.")).isVisible();
+		}
+	}
+
+	@Test
+	@DisplayName("numberTypeFilters=MOBILE accepts a valid Hungarian mobile number and stores the credential")
+	public void numberTypeFilterAcceptsMobileWhenMobileFilterIsSet() throws JsonProcessingException {
+		// +36201234567 is classified as MOBILE by libphonenumber, so it passes the
+		// MOBILE type filter and the credential is stored normally.
+		final var realm = setupRealm(Map.of(
+			"normalizePhoneNumber", "true",
+			"numberTypeFilters", "MOBILE"
+		));
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			final var page = browser.newPage();
+			navigateToPhoneSetupForm(page);
+			submitPhoneAndVerifyCode(page, "+36201234567");
+		}
+
+		final var userId = realm.users().search("test@phasetwo.io").get(0).getId();
+		final var credentials = realm.users().get(userId).credentials();
+		final var mobileCredential = credentials.stream().filter(c -> "mobile-number".equals(c.getType())).findFirst();
+		assertTrue(mobileCredential.isPresent(), "Expected a mobile-number credential after the mobile number passed the type filter");
+		final var credentialData = MAPPER.readTree(mobileCredential.get().getCredentialData());
+		assertEquals("+36201234567", credentialData.get("mobileNumber").asText());
+	}
+
+	@Test
+	@DisplayName("numberTypeFilters=FIXED_LINE accepts a valid Hungarian landline and stores the credential")
+	public void numberTypeFilterAcceptsFixedLineWhenMobileFilterIsSet() throws JsonProcessingException {
+		// +36201234567 is classified as MOBILE by libphonenumber, so it passes the
+		// MOBILE type filter and the credential is stored normally.
+		final var realm = setupRealm(Map.of(
+			"normalizePhoneNumber", "true",
+			"numberTypeFilters", "FIXED_LINE"
+		));
+
+		try (final var playwright = Playwright.create();
+			 final var browser = playwright.chromium().connect(
+				 "ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+				 new BrowserType.ConnectOptions().setExposeNetwork("*"))) {
+
+			final var page = browser.newPage();
+			navigateToPhoneSetupForm(page);
+			submitPhoneAndVerifyCode(page, "+3629123456");
+		}
+
+		final var userId = realm.users().search("test@phasetwo.io").get(0).getId();
+		final var credentials = realm.users().get(userId).credentials();
+		final var mobileCredential = credentials.stream().filter(c -> "mobile-number".equals(c.getType())).findFirst();
+		assertTrue(mobileCredential.isPresent(), "Expected a mobile-number credential after the mobile number passed the type filter");
+		final var credentialData = MAPPER.readTree(mobileCredential.get().getCredentialData());
+		assertEquals("+3629123456", credentialData.get("mobileNumber").asText());
+	}
+}

--- a/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorTest.java
+++ b/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorTest.java
@@ -1,0 +1,129 @@
+package netzbegruenung.keycloak.authenticator;
+
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.options.AriaRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.resource.RealmResource;
+
+import java.util.Arrays;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import static netzbegruenung.keycloak.ArrayUtils.getLast;
+import static netzbegruenung.keycloak.KeycloakTestUtils.createOrUpdateExecutionConfig;
+import static org.mockserver.model.HttpRequest.request;
+
+public class SmsAuthenticatorTest extends AbstractAuthenticatorTest {
+
+	@Test
+	@DisplayName("A user who enters a correct but expired SMS code sees an expiry error")
+	public void expiredSmsCodeShowsError() throws InterruptedException {
+		BaseTest.setupSMSAuthenticatorForUser(this);
+		final var realm = findRealmByName("test-realm");
+		final var testRealm = realm.toRepresentation();
+
+		// Reduce TTL to 2 seconds for this test only, then restore via the existing config update path
+		final var smsExecution = realm.flows().getExecutions("Browser with SMS 2FA")
+			.stream()
+			.filter(e -> "mobile-number-authenticator".equals(e.getProviderId()))
+			.findFirst()
+			.orElseThrow();
+		createOrUpdateExecutionConfig(realm, smsExecution, config -> config.getConfig().put("ttl", "2"));
+
+		try (
+			final var playwright = Playwright.create();
+			final var browser = playwright
+				.chromium()
+				.connect(
+					"ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+					new BrowserType.ConnectOptions().setExposeNetwork("*")
+				);
+		) {
+			Page page = browser.newPage();
+			page.navigate(container.getAuthServerUrl() + "/realms/" + testRealm.getRealm() + "/account");
+
+			page.fill("#username", "test@phasetwo.io");
+			page.fill("#password", "test123");
+			page.click("#kc-login");
+
+			// Capture the real code before it expires
+			final var sentSmsRequest = getLast(mockServerClient.retrieveRecordedRequests(request().withPath("/sms")));
+			final var smsData = parseFormData(sentSmsRequest.getBody().getValue().toString());
+			final var verificationCode = extractCodeFromBody(smsData.get("body"));
+
+			// Wait long enough for the 2-second TTL to elapse
+			Thread.sleep(3000);
+
+			page.fill("#code", verificationCode);
+			page.locator("input[name='login']").click();
+
+			assertThat(page.getByText("The SMS code has expired.")).isVisible();
+		}
+	}
+
+	@Test
+	@DisplayName("A user who enters an invalid SMS code sees an error and can retry")
+	public void invalidSmsCodeShowsError() {
+		BaseTest.setupSMSAuthenticatorForUser(this);
+		final var realm = findRealmByName("test-realm");
+		final var testRealm = realm.toRepresentation();
+		try (
+			final var playwright = Playwright.create();
+			final var browser = playwright
+				.chromium()
+				.connect(
+					"ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+					new BrowserType.ConnectOptions().setExposeNetwork("*")
+				);
+		) {
+			Page page = browser.newPage();
+			page.navigate(container.getAuthServerUrl() + "/realms/" + testRealm.getRealm() + "/account");
+
+			page.fill("#username", "test@phasetwo.io");
+			page.fill("#password", "test123");
+			page.click("#kc-login");
+
+			// Enter a deliberately wrong code instead of the real one
+			page.fill("#code", "000000");
+			page.locator("input[name='login']").click();
+
+			// Should stay on the SMS code page — not redirected to account on success
+			assertThat(page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName("SMS Code"))).isVisible();
+		}
+	}
+
+	@Test
+	@DisplayName("A user, who's set up correctly, is prompted for their SMS code")
+	public void promptExistingAndSetUpUserForSms2FA() {
+		BaseTest.setupSMSAuthenticatorForUser(this);
+		final var realm = findRealmByName("test-realm");
+		final var testRealm = realm.toRepresentation();
+		try (
+			final var playwright = Playwright.create();
+			final var browser = playwright
+				.chromium()
+				.connect(
+					"ws://%s:%d".formatted(playwrightContainer.getHost(), playwrightContainer.getMappedPort(3000)),
+					new BrowserType.ConnectOptions().setExposeNetwork("*")
+				);
+		) {
+			Page page = browser.newPage();
+			page.navigate(container.getAuthServerUrl() + "/realms/" + testRealm.getRealm() + "/account");
+
+			page.fill("#username", "test@phasetwo.io");
+			page.fill("#password", "test123");
+			page.click("#kc-login");
+
+			final var sentSmsRequest = getLast(mockServerClient.retrieveRecordedRequests(request().withPath("/sms")));
+			final var smsRequestBody = sentSmsRequest.getBody().getValue().toString();
+			final var smsData = parseFormData(smsRequestBody);
+			final var verificationCode = extractCodeFromBody(smsData.get("body"));
+			page.fill("#code", verificationCode);
+			page.locator("input[name='login']").click();
+
+			assertThat(page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName("Personal info"))).isVisible();
+		}
+	}
+}


### PR DESCRIPTION
Closed #351

Note: The tests were collaboratively authored - I wrote the initial tests and used Claude Code to generate additional test cases covering missing branches.