### PR TITLE
feat(enforce-mfa): conditional-enforce-mfa and mfa-credential-condition

### DIFF
--- a/enforce-mfa/README.md
+++ b/enforce-mfa/README.md
@@ -44,3 +44,20 @@ The expected flow must contain at least two subflows. The subflow, which contain
 Example:
 
 ![Example Configuration](Enforce-MFA.png)
+
+## Conditional Enforce MFA (`conditional-enforce-mfa`) and MFA credential condition (`mfa-credential-condition`)
+
+The same JAR also registers:
+
+- **`conditional-enforce-mfa`**: same login form as **Enforce MFA** (`enforce-mfa.ftl`). Offered methods are taken only from authenticator config (`offeredRequiredActions`). Optional skip: **`mfaSetupOptional`** (same key as Enforce MFA).
+- **`mfa-credential-condition`**: conditional on credentials already enrolled (`credentialTypes`, combine **ALL** / **ANY**, optional **invertMatch**).
+
+Simple example (excerpt of a browser flow):
+
+```
+- Register MFA (subflow CONDITIONAL)
+-- Condition - MFA credentials (enrolled) REQUIRED   [invertMatch: true, types e.g. otp + webauthn, combine ANY]
+-- Conditional Enforce MFA (config lists) REQUIRED   [offered: CONFIGURE_TOTP, webauthn-register]
+```
+
+Here the condition can send users into the subflow when MFA is still missing; **Conditional Enforce MFA** then lets them pick one configured method until at least one offered enrollment is satisfied.

--- a/enforce-mfa/README.md
+++ b/enforce-mfa/README.md
@@ -44,3 +44,20 @@ The expected flow must contain at least two subflows. The subflow, which contain
 Example:
 
 ![Example Configuration](Enforce-MFA.png)
+
+## Conditional Enforce MFA (`conditional-enforce-mfa`) and MFA credential condition (`mfa-credential-condition`)
+
+The same JAR also registers:
+
+- **`conditional-enforce-mfa`**: same login form as **Enforce MFA** (`enforce-mfa.ftl`). Offered methods are taken only from authenticator config (`offeredRequiredActions`). Optional skip: **`mfaSetupOptional`** (same key as Enforce MFA).
+- **`mfa-credential-condition`**: conditional on credentials already enrolled (`credentialTypes`, combine **ALL** / **ANY**, optional **invertMatch**).
+
+Simple example (excerpt of a browser flow):
+
+```
+- Register MFA (subflow CONDITIONAL)
+-- Condition - MFA credentials enrolled REQUIRED   [invertMatch: true, types e.g. otp + webauthn, combine ANY]
+-- Conditional Enforce MFA REQUIRED   [offered: CONFIGURE_TOTP, webauthn-register]
+```
+
+Here the condition can send users into the subflow when MFA is still missing; **Conditional Enforce MFA** then lets them pick one configured method until at least one offered enrollment is satisfied.

--- a/enforce-mfa/README.md
+++ b/enforce-mfa/README.md
@@ -56,8 +56,8 @@ Simple example (excerpt of a browser flow):
 
 ```
 - Register MFA (subflow CONDITIONAL)
--- Condition - MFA credentials (enrolled) REQUIRED   [invertMatch: true, types e.g. otp + webauthn, combine ANY]
--- Conditional Enforce MFA (config lists) REQUIRED   [offered: CONFIGURE_TOTP, webauthn-register]
+-- Condition - MFA credentials enrolled REQUIRED   [invertMatch: true, types e.g. otp + webauthn, combine ANY]
+-- Conditional Enforce MFA REQUIRED   [offered: CONFIGURE_TOTP, webauthn-register]
 ```
 
 Here the condition can send users into the subflow when MFA is still missing; **Conditional Enforce MFA** then lets them pick one configured method until at least one offered enrollment is satisfied.

--- a/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/ConditionalEnforceMfaAuthenticator.java
+++ b/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/ConditionalEnforceMfaAuthenticator.java
@@ -1,0 +1,220 @@
+package netzbegruenung.keycloak.enforce_mfa;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.AuthenticationProcessor;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.Constants;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RequiredActionProviderModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * MFA enrollment screen driven only by this execution's config (offered required actions).
+ * {@link #configuredFor} uses {@link AuthenticationProcessor#CURRENT_AUTHENTICATION_EXECUTION} so the step works
+ * without scanning sibling subflows (unlike {@link EnforceMfaAuthenticator}).
+ */
+public class ConditionalEnforceMfaAuthenticator implements Authenticator {
+
+	private static final Logger LOG = Logger.getLogger(ConditionalEnforceMfaAuthenticator.class);
+
+	public static final String FORM_PARAM_MFA_METHOD = "mfaMethod";
+	/** Same i18n prefix as {@link EnforceMfaAuthenticator} ({@code enforce-mfa.ftl}). */
+	private static final String LOCALIZATION_PREFIX = "enforceMfa";
+
+	public static final Boolean CONFIG_OPTIONAL_DEFAULT_VALUE = false;
+
+	@Override
+	public void authenticate(AuthenticationFlowContext context) {
+		AuthenticatorConfigModel authCfg = context.getAuthenticatorConfig();
+		if (authCfg == null || authCfg.getConfig() == null) {
+			LOG.error("conditional-enforce-mfa: missing authenticator config");
+			failIllegal(context);
+			return;
+		}
+		List<String> offeredIds = EnforceMfaShared.splitMultivalued(authCfg.getConfig(), EnforceMfaShared.CONFIG_OFFERED);
+		if (offeredIds.isEmpty()) {
+			LOG.error("conditional-enforce-mfa: offeredRequiredActions is empty");
+			failIllegal(context);
+			return;
+		}
+
+		List<RequiredActionProviderModel> models = resolveOffered(context.getRealm(), offeredIds);
+		if (models.isEmpty()) {
+			LOG.errorf(
+				"No enabled required actions found for offered ids %s (realm=%s)",
+				offeredIds,
+				context.getRealm().getName()
+			);
+			failIllegal(context);
+			return;
+		}
+
+		Response challenge = context.form()
+			.setAttribute("mfa", models)
+			.setAttribute("isSetupOptional", isSetupOptional(authCfg))
+			.setAttribute("localizationPrefix", LOCALIZATION_PREFIX)
+			.createForm("enforce-mfa.ftl");
+		context.challenge(challenge);
+	}
+
+	private static void failIllegal(AuthenticationFlowContext context) {
+		Response errorResponse = context.form()
+			.setError("enforceMfaIllegalState")
+			.setAttribute("localizationPrefix", LOCALIZATION_PREFIX)
+			.createForm("enforce-mfa.ftl");
+		context.failure(AuthenticationFlowError.INTERNAL_ERROR, errorResponse);
+	}
+
+	private static List<RequiredActionProviderModel> resolveOffered(RealmModel realm, List<String> ids) {
+		List<RequiredActionProviderModel> out = new LinkedList<>();
+		for (String id : ids) {
+			findRequiredAction(realm, id).ifPresent(m -> {
+				if (m.isEnabled()) {
+					out.add(m);
+				}
+			});
+		}
+		return out;
+	}
+
+	private static Optional<RequiredActionProviderModel> findRequiredAction(RealmModel realm, String id) {
+		RequiredActionProviderModel m = realm.getRequiredActionProviderById(id);
+		if (m != null) {
+			return Optional.of(m);
+		}
+		m = realm.getRequiredActionProviderByAlias(id);
+		return Optional.ofNullable(m);
+	}
+
+	@Override
+	public void action(AuthenticationFlowContext context) {
+		MultivaluedMap<String, String> decodedFormParameters = context.getHttpRequest().getDecodedFormParameters();
+		AuthenticatorConfigModel authCfg = context.getAuthenticatorConfig();
+		if (authCfg == null || authCfg.getConfig() == null) {
+			LOG.error("conditional-enforce-mfa action: missing authenticator config");
+			context.failure(AuthenticationFlowError.INTERNAL_ERROR, context.form().createErrorPage(Response.Status.BAD_REQUEST));
+			return;
+		}
+		if (isSetupOptional(authCfg)
+			&& (!decodedFormParameters.containsKey(FORM_PARAM_MFA_METHOD)
+			|| decodedFormParameters.getFirst(FORM_PARAM_MFA_METHOD).isBlank())) {
+			context.success();
+			return;
+		}
+
+		if (!decodedFormParameters.containsKey(FORM_PARAM_MFA_METHOD)) {
+			context.challenge(context.form().createErrorPage(Response.Status.BAD_REQUEST));
+			context.failure(AuthenticationFlowError.CREDENTIAL_SETUP_REQUIRED);
+			return;
+		}
+
+		String action = decodedFormParameters.getFirst(FORM_PARAM_MFA_METHOD);
+
+		List<String> offeredIds = EnforceMfaShared.splitMultivalued(authCfg.getConfig(), EnforceMfaShared.CONFIG_OFFERED);
+		if (offeredIds.stream().noneMatch(action::equals)) {
+			context.challenge(context.form().createErrorPage(Response.Status.BAD_REQUEST));
+			context.failure(AuthenticationFlowError.CREDENTIAL_SETUP_REQUIRED);
+			return;
+		}
+
+		AuthenticationSessionModel authenticationSession = context.getAuthenticationSession();
+		if (!authenticationSession.getRequiredActions().contains(action)) {
+			authenticationSession.addRequiredAction(action);
+		}
+		context.success();
+	}
+
+	private boolean isSetupOptional(AuthenticatorConfigModel config) {
+		return Optional.ofNullable(config)
+			.map(AuthenticatorConfigModel::getConfig)
+			.map(c -> c.getOrDefault(EnforceMfaShared.CONFIG_OPTIONAL_NAME, String.valueOf(CONFIG_OPTIONAL_DEFAULT_VALUE)))
+			.map(Boolean::parseBoolean)
+			.orElse(CONFIG_OPTIONAL_DEFAULT_VALUE);
+	}
+
+	@Override
+	public boolean requiresUser() {
+		return true;
+	}
+
+	@Override
+	public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+		Optional<AuthenticatorConfigModel> cfg = resolveOwnAuthenticatorConfig(session, realm);
+		if (cfg.isEmpty()) {
+			LOG.debug("[conditional-enforce-mfa] no config from auth note; assume step still required");
+			return true;
+		}
+		return needsEnrollment(session, realm, user, cfg.get());
+	}
+
+	/**
+	 * Step still required until at least one offered required action is satisfied (credential / pending state).
+	 */
+	static boolean needsEnrollment(
+		KeycloakSession session,
+		RealmModel realm,
+		UserModel user,
+		AuthenticatorConfigModel authCfg
+	) {
+		if (authCfg == null || authCfg.getConfig() == null) {
+			return true;
+		}
+		List<String> offeredIds = EnforceMfaShared.splitMultivalued(authCfg.getConfig(), EnforceMfaShared.CONFIG_OFFERED);
+		if (offeredIds.isEmpty()) {
+			return true;
+		}
+		boolean anyOfferedSatisfied = offeredIds.stream()
+			.anyMatch(id -> RequiredActionEnrollment.isSatisfied(session, realm, user, id));
+		return !anyOfferedSatisfied;
+	}
+
+	/**
+	 * Resolves the {@link AuthenticatorConfigModel} for the execution currently being evaluated, without walking flows.
+	 */
+	static Optional<AuthenticatorConfigModel> resolveOwnAuthenticatorConfig(KeycloakSession session, RealmModel realm) {
+		var ctx = session.getContext();
+		if (ctx == null) {
+			return Optional.empty();
+		}
+		var authSession = ctx.getAuthenticationSession();
+		if (authSession == null) {
+			return Optional.empty();
+		}
+		String execId = authSession.getAuthNote(AuthenticationProcessor.CURRENT_AUTHENTICATION_EXECUTION);
+		if (execId == null || execId.isBlank()) {
+			execId = authSession.getAuthNote(Constants.AUTHENTICATION_EXECUTION);
+		}
+		if (execId == null || execId.isBlank()) {
+			return Optional.empty();
+		}
+		AuthenticationExecutionModel execution = realm.getAuthenticationExecutionById(execId);
+		if (execution == null || !ConditionalEnforceMfaAuthenticatorFactory.PROVIDER_ID.equals(execution.getAuthenticator())) {
+			return Optional.empty();
+		}
+		String cfgId = execution.getAuthenticatorConfig();
+		if (cfgId == null || cfgId.isBlank()) {
+			return Optional.empty();
+		}
+		return Optional.ofNullable(realm.getAuthenticatorConfigById(cfgId));
+	}
+
+	@Override
+	public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+	}
+
+	@Override
+	public void close() {
+	}
+}

--- a/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/ConditionalEnforceMfaAuthenticatorFactory.java
+++ b/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/ConditionalEnforceMfaAuthenticatorFactory.java
@@ -1,0 +1,96 @@
+package netzbegruenung.keycloak.enforce_mfa;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+
+import java.util.List;
+
+public class ConditionalEnforceMfaAuthenticatorFactory implements AuthenticatorFactory {
+
+	public static final String PROVIDER_ID = "conditional-enforce-mfa";
+
+	private static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
+		AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+		AuthenticationExecutionModel.Requirement.DISABLED,
+		AuthenticationExecutionModel.Requirement.REQUIRED
+	};
+
+	@Override
+	public String getDisplayType() {
+		return "Conditional Enforce MFA (config lists)";
+	}
+
+	@Override
+	public String getReferenceCategory() {
+		return null;
+	}
+
+	@Override
+	public boolean isConfigurable() {
+		return true;
+	}
+
+	@Override
+	public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+		return REQUIREMENT_CHOICES;
+	}
+
+	@Override
+	public boolean isUserSetupAllowed() {
+		return false;
+	}
+
+	@Override
+	public String getHelpText() {
+		return "Offered = choices on screen. The step completes once at least one offered method is satisfied. "
+			+ "Does not read sibling subflows; uses this execution's config only (current.authentication.execution note).";
+	}
+
+	@Override
+	public List<ProviderConfigProperty> getConfigProperties() {
+		return ProviderConfigurationBuilder.create()
+			.property()
+			.name(EnforceMfaShared.CONFIG_OFFERED)
+			.label("Offered required actions")
+			.helpText("Choices shown to the user. Must exist and be enabled in the realm.")
+			.type(ProviderConfigProperty.MULTIVALUED_LIST_TYPE)
+			.options(EnforceMfaShared.REQUIRED_ACTION_OPTIONS)
+			.add()
+			.property()
+			.name(EnforceMfaShared.CONFIG_OPTIONAL_NAME)
+			.label("MFA setup is optional")
+			.helpText("Users can skip the setup screen.")
+			.type(ProviderConfigProperty.BOOLEAN_TYPE)
+			.defaultValue(ConditionalEnforceMfaAuthenticator.CONFIG_OPTIONAL_DEFAULT_VALUE)
+			.add()
+			.build();
+	}
+
+	@Override
+	public Authenticator create(KeycloakSession session) {
+		return new ConditionalEnforceMfaAuthenticator();
+	}
+
+	@Override
+	public void init(Config.Scope config) {
+	}
+
+	@Override
+	public void postInit(KeycloakSessionFactory factory) {
+	}
+
+	@Override
+	public void close() {
+	}
+
+	@Override
+	public String getId() {
+		return PROVIDER_ID;
+	}
+}

--- a/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/ConditionalEnforceMfaAuthenticatorFactory.java
+++ b/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/ConditionalEnforceMfaAuthenticatorFactory.java
@@ -1,0 +1,96 @@
+package netzbegruenung.keycloak.enforce_mfa;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+
+import java.util.List;
+
+public class ConditionalEnforceMfaAuthenticatorFactory implements AuthenticatorFactory {
+
+	public static final String PROVIDER_ID = "conditional-enforce-mfa";
+
+	private static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
+		AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+		AuthenticationExecutionModel.Requirement.DISABLED,
+		AuthenticationExecutionModel.Requirement.REQUIRED
+	};
+
+	@Override
+	public String getDisplayType() {
+		return "Conditional Enforce MFA";
+	}
+
+	@Override
+	public String getReferenceCategory() {
+		return null;
+	}
+
+	@Override
+	public boolean isConfigurable() {
+		return true;
+	}
+
+	@Override
+	public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+		return REQUIREMENT_CHOICES;
+	}
+
+	@Override
+	public boolean isUserSetupAllowed() {
+		return false;
+	}
+
+	@Override
+	public String getHelpText() {
+		return "Offered = choices on screen. The step completes once at least one offered method is satisfied. "
+			+ "Does not read sibling subflows; uses this execution's config only (current.authentication.execution note).";
+	}
+
+	@Override
+	public List<ProviderConfigProperty> getConfigProperties() {
+		return ProviderConfigurationBuilder.create()
+			.property()
+			.name(EnforceMfaShared.CONFIG_OFFERED)
+			.label("Offered required actions")
+			.helpText("Choices shown to the user. Must exist and be enabled in the realm.")
+			.type(ProviderConfigProperty.MULTIVALUED_LIST_TYPE)
+			.options(EnforceMfaShared.REQUIRED_ACTION_OPTIONS)
+			.add()
+			.property()
+			.name(EnforceMfaShared.CONFIG_OPTIONAL_NAME)
+			.label("MFA setup is optional")
+			.helpText("Users can skip the setup screen.")
+			.type(ProviderConfigProperty.BOOLEAN_TYPE)
+			.defaultValue(ConditionalEnforceMfaAuthenticator.CONFIG_OPTIONAL_DEFAULT_VALUE)
+			.add()
+			.build();
+	}
+
+	@Override
+	public Authenticator create(KeycloakSession session) {
+		return new ConditionalEnforceMfaAuthenticator();
+	}
+
+	@Override
+	public void init(Config.Scope config) {
+	}
+
+	@Override
+	public void postInit(KeycloakSessionFactory factory) {
+	}
+
+	@Override
+	public void close() {
+	}
+
+	@Override
+	public String getId() {
+		return PROVIDER_ID;
+	}
+}

--- a/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/ConditionalEnforceMfaAuthenticatorFactory.java
+++ b/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/ConditionalEnforceMfaAuthenticatorFactory.java
@@ -23,7 +23,7 @@ public class ConditionalEnforceMfaAuthenticatorFactory implements AuthenticatorF
 
 	@Override
 	public String getDisplayType() {
-		return "Conditional Enforce MFA (config lists)";
+		return "Conditional Enforce MFA";
 	}
 
 	@Override

--- a/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/EnforceMfaShared.java
+++ b/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/EnforceMfaShared.java
@@ -1,0 +1,62 @@
+package netzbegruenung.keycloak.enforce_mfa;
+
+import org.keycloak.authentication.requiredactions.WebAuthnPasswordlessRegisterFactory;
+import org.keycloak.authentication.requiredactions.WebAuthnRegisterFactory;
+import org.keycloak.credential.OTPCredentialProviderFactory;
+import org.keycloak.credential.WebAuthnCredentialProviderFactory;
+import org.keycloak.credential.WebAuthnPasswordlessCredentialProviderFactory;
+import org.keycloak.models.Constants;
+import org.keycloak.models.UserModel;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shared config keys, admin multiselect option lists, and parsing of multivalued authenticator config (Keycloak delimiter).
+ */
+public final class EnforceMfaShared {
+
+	private EnforceMfaShared() {
+	}
+
+	/** {@link ConditionalEnforceMfaAuthenticator} config: multiselect required actions shown on the screen. */
+	public static final String CONFIG_OFFERED = "offeredRequiredActions";
+	/** Same key as {@link EnforceMfaAuthenticator#CONFIG_OPTIONAL_NAME}. */
+	public static final String CONFIG_OPTIONAL_NAME = "mfaSetupOptional";
+
+	/** Credential type ids for {@link MfaCredentialConditionFactory} admin UI. */
+	public static final List<String> CREDENTIAL_TYPE_OPTIONS = List.of(
+		OTPCredentialProviderFactory.PROVIDER_ID,
+		WebAuthnCredentialProviderFactory.PROVIDER_ID,
+		WebAuthnPasswordlessCredentialProviderFactory.PROVIDER_ID,
+		"email-authenticator", /* from mesutpiskin/keycloak-2fa-email-authenticator */
+		"mobile-number" /* from netzbegruenung/keycloak-mfa-plugins/sms-authenticator */
+	);
+
+	/** Required action ids for {@link ConditionalEnforceMfaAuthenticatorFactory} admin UI. */
+	public static final List<String> REQUIRED_ACTION_OPTIONS = List.of(
+		UserModel.RequiredAction.CONFIGURE_TOTP.name(),
+		WebAuthnRegisterFactory.PROVIDER_ID,
+		WebAuthnPasswordlessRegisterFactory.PROVIDER_ID,
+		"email-authenticator-setup", /* from mesutpiskin/keycloak-2fa-email-authenticator */
+		"mobile_number_config" /* from netzbegruenung/keycloak-mfa-plugins/sms-authenticator */
+	);
+
+	/**
+	 * Lit une entrée de config authenticator telle que stockée par l’admin (valeurs jointes avec
+	 * {@link Constants#CFG_DELIMITER}).
+	 */
+	public static List<String> splitMultivalued(Map<String, String> cfg, String key) {
+		if (cfg == null) {
+			return List.of();
+		}
+		String v = cfg.get(key);
+		if (v == null || v.isBlank()) {
+			return List.of();
+		}
+		return Constants.CFG_DELIMITER_PATTERN.splitAsStream(v)
+			.map(String::trim)
+			.filter(s -> !s.isEmpty())
+			.toList();
+	}
+}

--- a/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/MfaCredentialCondition.java
+++ b/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/MfaCredentialCondition.java
@@ -1,0 +1,101 @@
+package netzbegruenung.keycloak.enforce_mfa;
+
+import org.jboss.logging.Logger;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.authenticators.conditional.ConditionalAuthenticator;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Condition that inspects credentials already registered for the current user and matches when a
+ * policy (AND/OR list of credential types) is satisfied. Use {@code invertMatch} to branch the
+ * opposite way (e.g. enrollment when credentials are missing).
+ */
+public final class MfaCredentialCondition implements ConditionalAuthenticator {
+
+	static final MfaCredentialCondition INSTANCE = new MfaCredentialCondition();
+
+	private static final Logger LOG = Logger.getLogger(MfaCredentialCondition.class);
+
+	private MfaCredentialCondition() {
+	}
+
+	@Override
+	public boolean matchCondition(AuthenticationFlowContext context) {
+		UserModel user = context.getUser();
+		if (user == null) {
+			LOG.debug("mfa-credential-condition: no user in context");
+			return applyInvert(false, context.getAuthenticatorConfig());
+		}
+
+		AuthenticatorConfigModel cfg = context.getAuthenticatorConfig();
+		boolean satisfied = evaluatePolicy(user, cfg);
+		return applyInvert(satisfied, cfg);
+	}
+
+	private static boolean applyInvert(boolean value, AuthenticatorConfigModel cfg) {
+		if (cfg == null || cfg.getConfig() == null) {
+			return value;
+		}
+		String inv = cfg.getConfig().get(MfaCredentialConditionFactory.CONFIG_INVERT_MATCH);
+		if (Boolean.parseBoolean(inv)) {
+			return !value;
+		}
+		return value;
+	}
+
+	static boolean evaluatePolicy(UserModel user, AuthenticatorConfigModel cfg) {
+		if (cfg == null || cfg.getConfig() == null) {
+			LOG.warn("mfa-credential-condition: missing config");
+			return false;
+		}
+		var map = cfg.getConfig();
+		List<String> types = EnforceMfaShared.splitMultivalued(map, MfaCredentialConditionFactory.CONFIG_CREDENTIAL_TYPES);
+		if (types.isEmpty()) {
+			LOG.warn("mfa-credential-condition: credentialTypes is empty");
+			return false;
+		}
+
+		String combineRaw = map.getOrDefault(
+			MfaCredentialConditionFactory.CONFIG_COMBINE,
+			MfaCredentialConditionFactory.COMBINE_ALL
+		).trim().toUpperCase(Locale.ROOT);
+
+		boolean requireAll = switch (combineRaw) {
+			case MfaCredentialConditionFactory.COMBINE_ALL -> true;
+			case MfaCredentialConditionFactory.COMBINE_ANY -> false;
+			default -> {
+				LOG.warnv("mfa-credential-condition: unknown combine \"{0}\", defaulting to ALL", combineRaw);
+				yield true;
+			}
+		};
+
+		var credMgr = user.credentialManager();
+		if (requireAll) {
+			return types.stream().allMatch(credMgr::isConfiguredFor);
+		}
+		return types.stream().anyMatch(credMgr::isConfiguredFor);
+	}
+
+	@Override
+	public void action(AuthenticationFlowContext context) {
+	}
+
+	@Override
+	public boolean requiresUser() {
+		return true;
+	}
+
+	@Override
+	public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+	}
+
+	@Override
+	public void close() {
+	}
+}

--- a/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/MfaCredentialConditionFactory.java
+++ b/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/MfaCredentialConditionFactory.java
@@ -1,0 +1,110 @@
+package netzbegruenung.keycloak.enforce_mfa;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.authenticators.conditional.ConditionalAuthenticator;
+import org.keycloak.authentication.authenticators.conditional.ConditionalAuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+
+import java.util.List;
+
+public class MfaCredentialConditionFactory implements ConditionalAuthenticatorFactory {
+
+	public static final String PROVIDER_ID = "mfa-credential-condition";
+
+	public static final String CONFIG_CREDENTIAL_TYPES = "credentialTypes";
+	public static final String CONFIG_COMBINE = "combine";
+	public static final String CONFIG_INVERT_MATCH = "invertMatch";
+
+	public static final String COMBINE_ALL = "ALL";
+	public static final String COMBINE_ANY = "ANY";
+
+	private static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
+		AuthenticationExecutionModel.Requirement.REQUIRED,
+		AuthenticationExecutionModel.Requirement.DISABLED,
+	};
+
+	@Override
+	public ConditionalAuthenticator getSingleton() {
+		return MfaCredentialCondition.INSTANCE;
+	}
+
+	@Override
+	public String getDisplayType() {
+		return "Condition - MFA credentials (enrolled)";
+	}
+
+	@Override
+	public String getReferenceCategory() {
+		return ConditionalAuthenticatorFactory.REFERENCE_CATEGORY;
+	}
+
+	@Override
+	public boolean isConfigurable() {
+		return true;
+	}
+
+	@Override
+	public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+		return REQUIREMENT_CHOICES;
+	}
+
+	@Override
+	public boolean isUserSetupAllowed() {
+		return false;
+	}
+
+	@Override
+	public String getHelpText() {
+		return "Matches when the user's registered credentials satisfy the policy. "
+			+ "Select credential types (multiselect), then ALL (every type present) or ANY (at least one). "
+			+ "Enable « Invert match » to branch when the policy is not satisfied (e.g. drive enrollment).";
+	}
+
+	@Override
+	public List<ProviderConfigProperty> getConfigProperties() {
+		return ProviderConfigurationBuilder.create()
+			.property()
+			.name(CONFIG_CREDENTIAL_TYPES)
+			.label("Credential types")
+			.helpText("Types already enrolled for the user (checked via Keycloak credential manager).")
+			.type(ProviderConfigProperty.MULTIVALUED_LIST_TYPE)
+			.options(EnforceMfaShared.CREDENTIAL_TYPE_OPTIONS)
+			.add()
+			.property()
+			.name(CONFIG_COMBINE)
+			.label("Combine types")
+			.helpText("ALL: every selected type must be configured. ANY: at least one.")
+			.type(ProviderConfigProperty.LIST_TYPE)
+			.options(COMBINE_ALL, COMBINE_ANY)
+			.defaultValue(COMBINE_ALL)
+			.add()
+			.property()
+			.name(CONFIG_INVERT_MATCH)
+			.label("Invert match")
+			.helpText("If true, the outcome is reversed (true when the policy is not satisfied).")
+			.type(ProviderConfigProperty.BOOLEAN_TYPE)
+			.defaultValue(false)
+			.add()
+			.build();
+	}
+
+	@Override
+	public void init(Config.Scope config) {
+	}
+
+	@Override
+	public void postInit(KeycloakSessionFactory factory) {
+	}
+
+	@Override
+	public void close() {
+	}
+
+	@Override
+	public String getId() {
+		return PROVIDER_ID;
+	}
+}

--- a/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/MfaCredentialConditionFactory.java
+++ b/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/MfaCredentialConditionFactory.java
@@ -33,7 +33,7 @@ public class MfaCredentialConditionFactory implements ConditionalAuthenticatorFa
 
 	@Override
 	public String getDisplayType() {
-		return "Condition - MFA credentials (enrolled)";
+		return "Condition - MFA credentials enrolled";
 	}
 
 	@Override

--- a/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/MfaCredentialConditionFactory.java
+++ b/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/MfaCredentialConditionFactory.java
@@ -1,0 +1,110 @@
+package netzbegruenung.keycloak.enforce_mfa;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.authenticators.conditional.ConditionalAuthenticator;
+import org.keycloak.authentication.authenticators.conditional.ConditionalAuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+
+import java.util.List;
+
+public class MfaCredentialConditionFactory implements ConditionalAuthenticatorFactory {
+
+	public static final String PROVIDER_ID = "mfa-credential-condition";
+
+	public static final String CONFIG_CREDENTIAL_TYPES = "credentialTypes";
+	public static final String CONFIG_COMBINE = "combine";
+	public static final String CONFIG_INVERT_MATCH = "invertMatch";
+
+	public static final String COMBINE_ALL = "ALL";
+	public static final String COMBINE_ANY = "ANY";
+
+	private static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
+		AuthenticationExecutionModel.Requirement.REQUIRED,
+		AuthenticationExecutionModel.Requirement.DISABLED,
+	};
+
+	@Override
+	public ConditionalAuthenticator getSingleton() {
+		return MfaCredentialCondition.INSTANCE;
+	}
+
+	@Override
+	public String getDisplayType() {
+		return "Condition - MFA credentials enrolled";
+	}
+
+	@Override
+	public String getReferenceCategory() {
+		return ConditionalAuthenticatorFactory.REFERENCE_CATEGORY;
+	}
+
+	@Override
+	public boolean isConfigurable() {
+		return true;
+	}
+
+	@Override
+	public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+		return REQUIREMENT_CHOICES;
+	}
+
+	@Override
+	public boolean isUserSetupAllowed() {
+		return false;
+	}
+
+	@Override
+	public String getHelpText() {
+		return "Matches when the user's registered credentials satisfy the policy. "
+			+ "Select credential types (multiselect), then ALL (every type present) or ANY (at least one). "
+			+ "Enable « Invert match » to branch when the policy is not satisfied (e.g. drive enrollment).";
+	}
+
+	@Override
+	public List<ProviderConfigProperty> getConfigProperties() {
+		return ProviderConfigurationBuilder.create()
+			.property()
+			.name(CONFIG_CREDENTIAL_TYPES)
+			.label("Credential types")
+			.helpText("Types already enrolled for the user (checked via Keycloak credential manager).")
+			.type(ProviderConfigProperty.MULTIVALUED_LIST_TYPE)
+			.options(EnforceMfaShared.CREDENTIAL_TYPE_OPTIONS)
+			.add()
+			.property()
+			.name(CONFIG_COMBINE)
+			.label("Combine types")
+			.helpText("ALL: every selected type must be configured. ANY: at least one.")
+			.type(ProviderConfigProperty.LIST_TYPE)
+			.options(COMBINE_ALL, COMBINE_ANY)
+			.defaultValue(COMBINE_ALL)
+			.add()
+			.property()
+			.name(CONFIG_INVERT_MATCH)
+			.label("Invert match")
+			.helpText("If true, the outcome is reversed (true when the policy is not satisfied).")
+			.type(ProviderConfigProperty.BOOLEAN_TYPE)
+			.defaultValue(false)
+			.add()
+			.build();
+	}
+
+	@Override
+	public void init(Config.Scope config) {
+	}
+
+	@Override
+	public void postInit(KeycloakSessionFactory factory) {
+	}
+
+	@Override
+	public void close() {
+	}
+
+	@Override
+	public String getId() {
+		return PROVIDER_ID;
+	}
+}

--- a/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/RequiredActionEnrollment.java
+++ b/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/RequiredActionEnrollment.java
@@ -1,0 +1,38 @@
+package netzbegruenung.keycloak.enforce_mfa;
+
+import org.keycloak.authentication.requiredactions.WebAuthnPasswordlessRegisterFactory;
+import org.keycloak.authentication.requiredactions.WebAuthnRegisterFactory;
+import org.keycloak.credential.OTPCredentialProviderFactory;
+import org.keycloak.credential.WebAuthnCredentialProviderFactory;
+import org.keycloak.credential.WebAuthnPasswordlessCredentialProviderFactory;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+
+import java.util.Map;
+
+/**
+ * Determines whether a required action's enrollment can be considered satisfied (credential present).
+ */
+public final class RequiredActionEnrollment {
+
+	private static final Map<String, String> CREDENTIAL_TYPE_BY_REQUIRED_ACTION_ID = Map.of(
+		UserModel.RequiredAction.CONFIGURE_TOTP.name(), OTPCredentialProviderFactory.PROVIDER_ID,
+		WebAuthnRegisterFactory.PROVIDER_ID, WebAuthnCredentialProviderFactory.PROVIDER_ID,
+		WebAuthnPasswordlessRegisterFactory.PROVIDER_ID, WebAuthnPasswordlessCredentialProviderFactory.PROVIDER_ID,
+		"email-authenticator-setup", "email-authenticator", /* from mesutpiskin/keycloak-2fa-email-authenticator */
+		"mobile_number_config", "mobile-number", /* from netzbegruenung/keycloak-mfa-plugins/sms-authenticator */
+		"phone_validation_config", "mobile-number" /* from netzbegruenung/keycloak-mfa-plugins/sms-authenticator */
+	);
+
+	private RequiredActionEnrollment() {
+	}
+
+	public static boolean isSatisfied(KeycloakSession session, RealmModel realm, UserModel user, String requiredActionProviderId) {
+		String cred = CREDENTIAL_TYPE_BY_REQUIRED_ACTION_ID.get(requiredActionProviderId);
+		if (cred != null) {
+			return user.credentialManager().isConfiguredFor(cred);
+		}
+		return user.getRequiredActionsStream().noneMatch(requiredActionProviderId::equals);
+	}
+}

--- a/enforce-mfa/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/enforce-mfa/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -1,1 +1,3 @@
 netzbegruenung.keycloak.enforce_mfa.EnforceMfaAuthenticatorFactory
+netzbegruenung.keycloak.enforce_mfa.ConditionalEnforceMfaAuthenticatorFactory
+netzbegruenung.keycloak.enforce_mfa.MfaCredentialConditionFactory


### PR DESCRIPTION
Hello,

This PR extends the enforce-mfa module with two additional module while keeping the original enforce-mfa authenticator unchanged.

## Why
Classic enforce-mfa depends on flow layout: it discovers MFA choices from sibling executions in the same wrapper flow, and the MFA alternatives subflow must be first. That is powerful but tricky for simpler flows.
Operators also need a conditional that branches on already enrolled credential types (e.g. drive an enrollment subflow only when MFA is missing), without maintaining a separate extension JAR for that alone.

## What’s new
1. `conditional-enforce-mfa` (authenticator)
Configuration: multiselect required actions (offeredRequiredActions) + optional MFA setup is optional (mfaSetupOptional, same key as the classic authenticator).
Behaviour: the screen lists only the configured required actions (each must exist and be enabled in the realm). The user picks one; that required action is added to the authentication session. configuredFor does not walk the browser flow graph; it resolves this execution’s AuthenticatorConfigModel via Keycloak’s current.authentication.execution auth session note (with fallback to authenticationExecution), so the step works even when sibling “MFA alternative” executions are not modelled like the classic README example.
UX / i18n: reuses enforce-mfa.ftl and the same message keys as enforce-mfa (loginChooseMfa, enforceMfa.*, enforceMfaIllegalState) so realm themes do not need a second set of strings for this screen.
Policy: the step is no longer required once at least one offered method is considered satisfied

2. `mfa-credential-condition` (conditional authenticator)
Provider ID: mfa-credential-condition.
Configuration: Credential types (multiselect), Combine types (ALL / ANY), optional Invert match.
Behaviour: evaluates UserModel#credentialManager().isConfiguredFor(...) for the selected type ids (otp, webauthn, webauthn-passwordless, email-authenticator in the admin list; extendable in code via EnforceMfaShared.CREDENTIAL_TYPE_OPTIONS).

3. EnforceMfaShared
Single place for: authenticator config keys used by the new authenticator, admin multiselect option lists, and splitMultivalued parsing (Keycloak’s CFG_DELIMITER semantics). 

4. Documentation
README: original “How to use” content is preserved; a short appendix was added at the end describing the two new providers and a minimal CONDITIONAL subflow example.

No breaking change to existing enforce-mfa behaviour or configuration.

I hope this will be helpful to others,
Thomas