### PR TITLE
fix(sms): stabilize enrollment flow and required-action handling

### DIFF
--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/LoginUiBackLink.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/LoginUiBackLink.java
@@ -1,0 +1,89 @@
+package netzbegruenung.keycloak.authenticator;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.services.Urls;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.net.URI;
+
+/**
+ * Resolves a sensible "back to app" target for SMS-related UIs instead of {@code href="/"} (Keycloak root).
+ */
+public final class LoginUiBackLink {
+
+	/** Account Console path (Keycloak 25+): connection methods / MFA list. */
+	private static final String ACCOUNT_SIGNING_IN_PATH = "account-security/signing-in";
+
+	private LoginUiBackLink() {
+	}
+
+	/**
+	 * After cancelling SMS enrollment from the account console, send users to Signing in rather than a generic restart.
+	 */
+	public static String smsEnrollmentAbortHref(RealmModel realm, AuthenticationSessionModel authSession, UriInfo uriInfo) {
+		if (authSession != null && authSession.getClient() != null) {
+			String cid = authSession.getClient().getClientId();
+			if ("account-console".equals(cid) || "account".equals(cid)) {
+				URI accountRoot = Urls.accountBase(uriInfo.getBaseUri()).build(realm.getName());
+				return UriBuilder.fromUri(accountRoot).path(ACCOUNT_SIGNING_IN_PATH).build().normalize().toString();
+			}
+		}
+		return href(realm, authSession, uriInfo);
+	}
+
+	public static String href(RealmModel realm, AuthenticationSessionModel authSession, UriInfo uriInfo) {
+		URI baseUri = uriInfo.getBaseUri();
+		ClientModel client = authSession != null ? authSession.getClient() : null;
+
+		if (client != null) {
+			String fromClient = firstNonBlank(client.getRootUrl(), client.getBaseUrl());
+			String absolutized = absolutize(baseUri, fromClient);
+			if (absolutized != null) {
+				return absolutized;
+			}
+			String clientId = client.getClientId();
+			if ("account-console".equals(clientId) || "account".equals(clientId)) {
+				return Urls.accountBase(baseUri).build(realm.getName()).toString();
+			}
+		}
+
+		if (authSession != null) {
+			String redirect = authSession.getRedirectUri();
+			if (redirect != null && !redirect.isBlank()) {
+				return redirect.trim();
+			}
+		}
+
+		return Urls.accountBase(baseUri).build(realm.getName()).toString();
+	}
+
+	private static String firstNonBlank(String a, String b) {
+		if (a != null && !a.isBlank()) {
+			return a;
+		}
+		if (b != null && !b.isBlank()) {
+			return b;
+		}
+		return null;
+	}
+
+	private static String absolutize(URI keycloakBase, String ref) {
+		if (ref == null || ref.isBlank()) {
+			return null;
+		}
+		String t = ref.trim();
+		try {
+			URI u = URI.create(t);
+			if (u.isAbsolute()) {
+				return u.normalize().toString();
+			}
+			return keycloakBase.resolve(u).normalize().toString();
+		} catch (IllegalArgumentException e) {
+			return null;
+		}
+	}
+}

--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/PhoneNumberRequiredAction.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/PhoneNumberRequiredAction.java
@@ -28,6 +28,7 @@ import com.google.i18n.phonenumbers.Phonenumber.PhoneNumber;
 import jakarta.ws.rs.core.Response;
 import netzbegruenung.keycloak.authenticator.credentials.SmsAuthCredentialModel;
 import org.jboss.logging.Logger;
+import org.keycloak.authentication.AuthenticationProcessor;
 import org.keycloak.authentication.CredentialRegistrator;
 import org.keycloak.authentication.InitiatedActionSupport;
 import org.keycloak.authentication.RequiredActionContext;
@@ -35,7 +36,9 @@ import org.keycloak.authentication.RequiredActionProvider;
 import org.keycloak.authentication.requiredactions.WebAuthnRegisterFactory;
 import org.keycloak.credential.CredentialModel;
 import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.credential.OTPCredentialModel;
@@ -46,10 +49,19 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
+
+import org.keycloak.forms.login.LoginFormsProvider;
+import org.keycloak.services.resources.LoginActionsService;
+import org.keycloak.theme.Theme;
+
+import java.net.URI;
+
+import jakarta.ws.rs.core.UriBuilder;
 
 public class PhoneNumberRequiredAction implements RequiredActionProvider, CredentialRegistrator {
 
@@ -113,21 +125,20 @@ public class PhoneNumberRequiredAction implements RequiredActionProvider, Creden
 				WebAuthnRegisterFactory.PROVIDER_ID,
 				UserModel.RequiredAction.UPDATE_PASSWORD.name()
 			);
-			Set<String> authSessionRequiredActions = context.getAuthenticationSession().getRequiredActions();
-			authSessionRequiredActions.retainAll(availableRequiredActions);
-			if (!authSessionRequiredActions.isEmpty()) {
-				// skip as relevant required action is already set
+			// Merge user + session queues: phone_validation often sits only on the session queue (e.g. after number submit).
+			// Session-only checks used to re-queue mobile_number in evaluateTriggers and show the phone step twice.
+			Set<String> mfaRequiredActionsPending = new HashSet<>(context.getAuthenticationSession().getRequiredActions());
+			context.getUser().getRequiredActionsStream().forEach(mfaRequiredActionsPending::add);
+			mfaRequiredActionsPending.retainAll(availableRequiredActions);
+			if (!mfaRequiredActionsPending.isEmpty()) {
 				return;
 			}
 
-			Stream<String> usersRequiredActions = context.getUser().getRequiredActionsStream();
-			if (usersRequiredActions.noneMatch(availableRequiredActions::contains)) {
-				logger.infof(
-					"No 2FA method configured for user: %s, setting required action for SMS authenticator",
-					context.getUser().getUsername()
-				);
-				context.getUser().addRequiredAction(PhoneNumberRequiredAction.PROVIDER_ID);
-			}
+			logger.infof(
+				"No 2FA method configured for user: %s, setting required action for SMS authenticator",
+				context.getUser().getUsername()
+			);
+			context.getUser().addRequiredAction(PhoneNumberRequiredAction.PROVIDER_ID);
 		}
 	}
 
@@ -172,18 +183,137 @@ public class PhoneNumberRequiredAction implements RequiredActionProvider, Creden
 		return countryList;
 	}
 
+	/**
+	 * Same contract as Keycloak's {@code RequiredActionContextResult#getActionUrl(String)}: first arg is the
+	 * client session code, not a provider id. {@code execution} is set explicitly (server always uses the current action).
+	 */
+	private static URI buildRequiredActionFormUri(
+		RequiredActionContext context,
+		String clientSessionCode,
+		String executionProviderId) {
+		UriBuilder b = LoginActionsService.requiredActionProcessor(context.getUriInfo());
+		b.queryParam(LoginActionsService.SESSION_CODE, clientSessionCode);
+		b.queryParam("execution", executionProviderId);
+		ClientModel client = context.getAuthenticationSession().getClient();
+		if (client != null) {
+			b.queryParam("client_id", client.getClientId());
+		} else {
+			String cid = context.getUriInfo().getQueryParameters().getFirst("client_id");
+			if (cid != null) {
+				b.queryParam("client_id", cid);
+			}
+		}
+		String tabId = context.getAuthenticationSession().getTabId();
+		if (tabId == null) {
+			tabId = context.getUriInfo().getQueryParameters().getFirst("tab_id");
+		}
+		if (tabId != null) {
+			b.queryParam("tab_id", tabId);
+		}
+		String clientData = AuthenticationProcessor.getClientData(
+			context.getSession(),
+			context.getAuthenticationSession()
+		);
+		if (clientData == null) {
+			clientData = context.getUriInfo().getQueryParameters().getFirst("client_data");
+		}
+		if (clientData != null) {
+			b.queryParam("client_data", clientData);
+		}
+		return b.build(context.getRealm().getName());
+	}
+
+	/**
+	 * Return to the phone step from SMS validation: issues a fresh {@code session_code} (required; reusing the old
+	 * one yields Keycloak's "Page has expired"). Does not use {@link #buildPhoneNumberForm(RequiredActionContext, URI)}
+	 * because {@code context.form()} would mint another code and desync the form action URL.
+	 */
+	public void showPhoneNumberFormAfterChangeNumber(RequiredActionContext context) {
+		// Keep current execution in sync with the shown form; otherwise getLastExecutionUrl / replaceState can keep
+		// phone_validation while the next GET mixes validation URL with the phone UI / RA queue.
+		context.getAuthenticationSession().setAuthNote(
+			AuthenticationProcessor.CURRENT_AUTHENTICATION_EXECUTION,
+			PROVIDER_ID
+		);
+		String code = context.generateCode();
+		URI action = buildRequiredActionFormUri(context, code, PROVIDER_ID);
+		LoginFormsProvider form = context
+			.getSession()
+			.getProvider(LoginFormsProvider.class)
+			.setAuthenticationSession(context.getAuthenticationSession())
+			.setUser(context.getUser())
+			.setActionUri(action)
+			.setExecution(PROVIDER_ID)
+			.setClientSessionCode(code)
+			.setAttribute(
+				"mobileInputFieldPlaceholder",
+				context.getAuthenticationSession().getAuthNote("mobileInputFieldPlaceholder")
+			)
+			.setAttribute("countryList", getCountryCodeList(context));
+		context.challenge(form.createForm("mobile_number_form.ftl"));
+	}
+
+	/**
+	 * Localized line for the code screen: shows the exact destination used for the SMS (same string as in session / send path).
+	 */
+	public static String buildSmsDestinationHint(
+		KeycloakSession session,
+		RealmModel realm,
+		UserModel user,
+		String rawDestination) {
+		if (rawDestination == null || rawDestination.isBlank()) {
+			return null;
+		}
+		try {
+			Theme theme = session.theme().getTheme(Theme.Type.LOGIN);
+			Locale locale = session.getContext().resolveLocale(user);
+			String pattern = theme.getEnhancedMessages(realm, locale).getProperty("smsAuthSentTo");
+			if (pattern == null) {
+				pattern = "The code was sent to %1$s";
+			}
+			return String.format(pattern, rawDestination);
+		} catch (Exception e) {
+			return rawDestination;
+		}
+	}
+
+	/**
+	 * Phone number form; when {@code formAction} is set, POST targets that URL (e.g. return from code validation).
+	 */
+	Response buildPhoneNumberForm(RequiredActionContext context, java.net.URI formAction) {
+		LoginFormsProvider form = context.form()
+			.setAttribute("mobileInputFieldPlaceholder", context.getAuthenticationSession().getAuthNote("mobileInputFieldPlaceholder"))
+			.setAttribute("countryList", getCountryCodeList(context));
+		if (formAction != null) {
+			form = form.setActionUri(formAction);
+		}
+		return form.createForm("mobile_number_form.ftl");
+	}
+
+	/** Shows the phone number form; optional custom form action URL. */
+	public void showPhoneNumberForm(RequiredActionContext context, java.net.URI formAction) {
+		context.challenge(buildPhoneNumberForm(context, formAction));
+	}
+
 	@Override
 	public void requiredActionChallenge(RequiredActionContext context) {
-		Response challenge = context.form()
-			.setAttribute("mobileInputFieldPlaceholder", context.getAuthenticationSession().getAuthNote("mobileInputFieldPlaceholder"))
-			.setAttribute("countryList", getCountryCodeList(context))
-			.createForm("mobile_number_form.ftl");
-		context.challenge(challenge);
+		context.challenge(buildPhoneNumberForm(context, null));
 	}
 
 	@Override
 	public void processAction(RequiredActionContext context) {
-		String mobileNumber = nonDigitPattern.matcher(context.getHttpRequest().getDecodedFormParameters().getFirst("mobile_number")).replaceAll("");
+		String enrollment = context.getHttpRequest().getDecodedFormParameters().getFirst(SmsEnrollmentAbandon.FORM_PARAM);
+		if (SmsEnrollmentAbandon.ACTION_CANCEL.equals(enrollment)) {
+			SmsEnrollmentAbandon.abandonAndRedirect(context);
+			return;
+		}
+
+		String mobileRaw = context.getHttpRequest().getDecodedFormParameters().getFirst("mobile_number");
+		if (mobileRaw == null) {
+			requiredActionChallenge(context);
+			return;
+		}
+		String mobileNumber = nonDigitPattern.matcher(mobileRaw).replaceAll("");
 		AuthenticationSessionModel authSession = context.getAuthenticationSession();
 
 		// get the country code from the select input if available and add it to the mobile number
@@ -218,7 +348,10 @@ public class PhoneNumberRequiredAction implements RequiredActionProvider, Creden
 
 		authSession.setAuthNote("mobile_number", mobileNumber);
 		logger.infof("Add required action for phone validation: [%s], user: %s", mobileNumber, context.getUser().getUsername());
-		context.getAuthenticationSession().addRequiredAction(PhoneValidationRequiredAction.PROVIDER_ID);
+		authSession.addRequiredAction(PhoneValidationRequiredAction.PROVIDER_ID);
+		// Both queues: some GETs without session_code only see user-level RAs; otherwise evaluateTriggers can re-add
+		// mobile_number and ordering puts the phone step ahead of the code step again.
+		context.getUser().addRequiredAction(PhoneValidationRequiredAction.PROVIDER_ID);
 		context.success();
 	}
 

--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/PhoneValidationRequiredAction.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/PhoneValidationRequiredAction.java
@@ -40,11 +40,14 @@ import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.theme.Theme;
 
 import java.util.Locale;
+
 import jakarta.ws.rs.core.Response;
 
 public class PhoneValidationRequiredAction implements RequiredActionProvider, CredentialRegistrator {
 	private static final Logger logger = Logger.getLogger(PhoneValidationRequiredAction.class);
 	public static final String PROVIDER_ID = "phone_validation_config";
+
+	private static final String ACTION_CHANGE_NUMBER = "change_number";
 
 	@Override
 	public void evaluateTriggers(RequiredActionContext context) {
@@ -52,7 +55,7 @@ public class PhoneValidationRequiredAction implements RequiredActionProvider, Cr
 
 	@Override
 	public void requiredActionChallenge(RequiredActionContext context) {
-		context.getUser().addRequiredAction(PhoneNumberRequiredAction.PROVIDER_ID);
+
 		try {
 			UserModel user = context.getUser();
 			RealmModel realm = context.getRealm();
@@ -78,9 +81,7 @@ public class PhoneValidationRequiredAction implements RequiredActionProvider, Cr
 
 			SmsServiceFactory.get(config.getConfig()).send(mobileNumber, smsText);
 
-			Response challenge = context.form()
-				.setAttribute("realm", realm)
-				.createForm(SmsAuthenticator.TPL_CODE);
+			Response challenge = buildSmsCodeForm(context, realm, mobileNumber);
 			context.challenge(challenge);
 		} catch (Exception e) {
 			logger.error(e.getMessage(), e);
@@ -90,6 +91,16 @@ public class PhoneValidationRequiredAction implements RequiredActionProvider, Cr
 
 	@Override
 	public void processAction(RequiredActionContext context) {
+		String enrollment = context.getHttpRequest().getDecodedFormParameters().getFirst(SmsEnrollmentAbandon.FORM_PARAM);
+		if (SmsEnrollmentAbandon.ACTION_CANCEL.equals(enrollment)) {
+			SmsEnrollmentAbandon.abandonAndRedirect(context);
+			return;
+		}
+		if (ACTION_CHANGE_NUMBER.equals(enrollment)) {
+			handleChangeNumber(context);
+			return;
+		}
+
 		String enteredCode = context.getHttpRequest().getDecodedFormParameters().getFirst("code");
 
 		AuthenticationSessionModel authSession = context.getAuthenticationSession();
@@ -98,8 +109,8 @@ public class PhoneValidationRequiredAction implements RequiredActionProvider, Cr
 		String ttl = authSession.getAuthNote("ttl");
 
 		if (code == null || ttl == null || enteredCode == null) {
-			logger.warn("Phone number is not set");
-			handleInvalidSmsCode(context);
+			logger.warn("SMS code session state missing or no code entered");
+			handleInvalidSmsCode(context, mobileNumber);
 			return;
 		}
 
@@ -121,8 +132,46 @@ public class PhoneValidationRequiredAction implements RequiredActionProvider, Cr
 			context.success();
 		} else {
 			// invalid or expired
-			handleInvalidSmsCode(context);
+			handleInvalidSmsCode(context, mobileNumber);
 		}
+	}
+
+	private void handleChangeNumber(RequiredActionContext context) {
+		AuthenticationSessionModel session = context.getAuthenticationSession();
+		UserModel user = context.getUser();
+		clearSmsEnrollmentState(session);
+		session.removeAuthNote("mobile_number");
+		user.removeRequiredAction(PhoneValidationRequiredAction.PROVIDER_ID);
+		user.removeRequiredAction(PhoneNumberRequiredAction.PROVIDER_ID);
+		session.removeRequiredAction(PhoneValidationRequiredAction.PROVIDER_ID);
+		session.removeRequiredAction(PhoneNumberRequiredAction.PROVIDER_ID);
+		// Same as initial enrollment (enforcement): one User-level RA, not user+session duplicate, so
+		// PhoneNumberRequiredAction.processAction + success() matches a first pass.
+		user.addRequiredAction(PhoneNumberRequiredAction.PROVIDER_ID);
+		session.addRequiredAction(PhoneNumberRequiredAction.PROVIDER_ID);
+		// Do not reuse the current URL (old session_code) after changing execution: ClientSessionCode no longer
+		// matches → "Page has expired". Same idea as RequiredActionContextResult#getActionUrl: new code from
+		// generateCode(), server-shaped URL, execution = phone entry.
+		new PhoneNumberRequiredAction().showPhoneNumberFormAfterChangeNumber(context);
+	}
+
+	private static void clearSmsEnrollmentState(AuthenticationSessionModel session) {
+		session.removeAuthNote("code");
+		session.removeAuthNote("ttl");
+	}
+
+	Response buildSmsCodeForm(RequiredActionContext context, RealmModel realm, String rawSendDestination) {
+		String line = PhoneNumberRequiredAction.buildSmsDestinationHint(
+			context.getSession(),
+			realm,
+			context.getUser(),
+			rawSendDestination
+		);
+		return context.form()
+			.setAttribute("realm", realm)
+			.setAttribute("smsEnrollmentMode", Boolean.TRUE)
+			.setAttribute("smsAuthSentToText", line)
+			.createForm(SmsAuthenticator.TPL_CODE);
 	}
 
 	private void handlePhoneToAttribute(RequiredActionContext context, String mobileNumber) {
@@ -136,10 +185,18 @@ public class PhoneValidationRequiredAction implements RequiredActionProvider, Cr
 		}
 	}
 
-	private void handleInvalidSmsCode(RequiredActionContext context) {
+	private void handleInvalidSmsCode(RequiredActionContext context, String e164) {
+		String line = PhoneNumberRequiredAction.buildSmsDestinationHint(
+			context.getSession(),
+			context.getRealm(),
+			context.getUser(),
+			e164
+		);
 		Response challenge = context
 			.form()
 			.setAttribute("realm", context.getRealm())
+			.setAttribute("smsEnrollmentMode", Boolean.TRUE)
+			.setAttribute("smsAuthSentToText", line)
 			.setError("smsAuthCodeInvalid")
 			.createForm(SmsAuthenticator.TPL_CODE);
 		context.challenge(challenge);

--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticator.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticator.java
@@ -89,7 +89,12 @@ public class SmsAuthenticator implements Authenticator, CredentialValidator<SmsA
 
 			SmsServiceFactory.get(config.getConfig()).send(mobileNumber, smsText);
 
-			context.challenge(context.form().setAttribute("realm", realm).createForm(TPL_CODE));
+			String destLine = PhoneNumberRequiredAction.buildSmsDestinationHint(session, realm, user, mobileNumber);
+			context.challenge(
+				context.form()
+					.setAttribute("realm", realm)
+					.setAttribute("smsAuthSentToText", destLine)
+					.createForm(TPL_CODE));
 		} catch (Exception e) {
 			context.failureChallenge(AuthenticationFlowError.INTERNAL_ERROR,
 				context.form().setError("smsAuthSmsNotSent", "Error. Use another method.")
@@ -124,8 +129,25 @@ public class SmsAuthenticator implements Authenticator, CredentialValidator<SmsA
 		} else {
 			// invalid
 			context.getEvent().user(context.getUser()).error("invalid_user_credentials");
+			String mobile = null;
+			try {
+				Optional<CredentialModel> model = context.getUser().credentialManager()
+					.getStoredCredentialsByTypeStream(SmsAuthCredentialModel.TYPE).findFirst();
+				if (model.isPresent()) {
+					mobile = JsonSerialization.readValue(model.get().getCredentialData(), SmsAuthCredentialData.class).getMobileNumber();
+				}
+			} catch (Exception ignored) {
+			}
+			String destLine = PhoneNumberRequiredAction.buildSmsDestinationHint(
+				context.getSession(),
+				context.getRealm(),
+				context.getUser(),
+				mobile
+			);
 			Response challenge = context.form()
 				.setError("smsAuthCodeInvalid")
+				.setAttribute("smsAuthSentToText", destLine)
+				.setAttribute("realm", context.getRealm())
 				.createForm("login-sms.ftl");
 			context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, challenge);
 		}

--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsEnrollmentAbandon.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsEnrollmentAbandon.java
@@ -1,0 +1,39 @@
+package netzbegruenung.keycloak.authenticator;
+
+import org.jboss.logging.Logger;
+import org.keycloak.authentication.RequiredActionContext;
+import org.keycloak.models.UserModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+import jakarta.ws.rs.core.Response;
+
+import java.net.URI;
+
+/**
+ * Shared cancel path for SMS enrollment (phone or code step); same redirect for all related required actions.
+ */
+public final class SmsEnrollmentAbandon {
+
+	public static final String FORM_PARAM = "sms_enrollment_action";
+	public static final String ACTION_CANCEL = "cancel";
+
+	private static final Logger logger = Logger.getLogger(SmsEnrollmentAbandon.class);
+
+	private SmsEnrollmentAbandon() {
+	}
+
+	public static void abandonAndRedirect(RequiredActionContext context) {
+		AuthenticationSessionModel session = context.getAuthenticationSession();
+		UserModel user = context.getUser();
+		session.removeAuthNote("code");
+		session.removeAuthNote("ttl");
+		session.removeAuthNote("mobile_number");
+		user.removeRequiredAction(PhoneNumberRequiredAction.PROVIDER_ID);
+		user.removeRequiredAction(PhoneValidationRequiredAction.PROVIDER_ID);
+		session.removeRequiredAction(PhoneNumberRequiredAction.PROVIDER_ID);
+		session.removeRequiredAction(PhoneValidationRequiredAction.PROVIDER_ID);
+		logger.infof("SMS enrollment abandoned: %s", user.getUsername());
+		URI target = URI.create(LoginUiBackLink.smsEnrollmentAbortHref(context.getRealm(), session, context.getUriInfo()));
+		context.challenge(Response.seeOther(target).build());
+	}
+}

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_ca.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_ca.properties
@@ -3,6 +3,9 @@ smsAuthText=El vostre codi SMS és %1$s i és vàlid durant %2$d minuts.
 smsAuthTitle=Codi SMS
 smsAuthLabel=Codi SMS
 smsAuthInstruction=Introduïu el codi que s’ha enviat al vostre dispositiu.
+smsAuthSentTo=S’ha enviat el codi a %1$s
+smsEnrollmentChangeNumber=Canviar el número de telèfon
+smsEnrollmentCancel=Cancel·lar
 
 smsAuthSmsNotSent=No s’ha pogut enviar el SMS, perquè {0}
 smsAuthCodeExpired=El codi SMS ha caducat.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_de.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_de.properties
@@ -3,6 +3,9 @@ smsAuthText=Ihr SMS Code lautet %1$s und ist gültig für %2$d Minuten.
 smsAuthTitle=SMS Code
 smsAuthLabel=SMS Code
 smsAuthInstruction=Geben Sie den SMS Code ein, den wir an Ihr Gerät gesendet haben.
+smsAuthSentTo=Der Code wurde an %1$s gesendet
+smsEnrollmentChangeNumber=Telefonnummer ändern
+smsEnrollmentCancel=Abbrechen
 
 smsAuthSmsNotSent=Die SMS konnte nicht gesendet werden. Grund: {0}
 smsAuthCodeExpired=Der SMS Code ist abgelaufen.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_en.properties
@@ -3,6 +3,9 @@ smsAuthText=Your SMS code is %1$s and is valid for %2$d minutes.
 smsAuthTitle=SMS Code
 smsAuthLabel=SMS Code
 smsAuthInstruction=Enter the code we sent to your device.
+smsAuthSentTo=The code was sent to %1$s
+smsEnrollmentChangeNumber=Change phone number
+smsEnrollmentCancel=Cancel
 
 smsAuthSmsNotSent=The SMS could not be sent, because of {0}
 smsAuthCodeExpired=The SMS code has expired.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_es.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_es.properties
@@ -3,6 +3,9 @@ smsAuthText=Su código SMS es %1$s y es válido durante %2$d minutos.
 smsAuthTitle=Código SMS
 smsAuthLabel=Código SMS
 smsAuthInstruction=Introduzca el código que se ha enviado a su dispositivo.
+smsAuthSentTo=El código se envió a %1$s
+smsEnrollmentChangeNumber=Cambiar número de teléfono
+smsEnrollmentCancel=Cancelar
 
 smsAuthSmsNotSent=El SMS no pudo ser enviado, porque {0}
 smsAuthCodeExpired=El código SMS ha caducado.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_fi.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_fi.properties
@@ -3,6 +3,9 @@ smsAuthText=Vahvistuskoodisi on %1$s ja se on voimassa %2$d minuuttia.
 smsAuthTitle=Vahvistuskoodi
 smsAuthLabel=Vahvistuskoodi
 smsAuthInstruction=Syötä koodi, jonka lähetimme laitteeseesi.
+smsAuthSentTo=Koodi lähetettiin numeroon %1$s
+smsEnrollmentChangeNumber=Vaihda puhelinnumeroa
+smsEnrollmentCancel=Peruuta
 
 smsAuthSmsNotSent=Tekstiviestiä ei voitu lähettää, koska {0}
 smsAuthCodeExpired=Vahvistuskoodi on vanhentunut.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_fr.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_fr.properties
@@ -3,6 +3,9 @@ smsAuthText=Votre code de vérification est %1$s et est valide pendant %2$d minu
 smsAuthTitle=Code de vérification par SMS
 smsAuthLabel=Code de vérification
 smsAuthInstruction=Entrez le code que nous avons envoyé à votre appareil.
+smsAuthSentTo=Le code a été envoyé au %1$s
+smsEnrollmentChangeNumber=Changer de numéro
+smsEnrollmentCancel=Annuler
 
 smsAuthSmsNotSent=Le SMS n'a pas pu être envoyé en raison de {0}
 smsAuthCodeExpired=Le code de vérification a expiré.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_it.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_it.properties
@@ -3,6 +3,9 @@ smsAuthText=Il tuo codice SMS è %1$s ed è valido per %2$d minuti.
 smsAuthTitle=Codice SMS
 smsAuthLabel=Codice SMS
 smsAuthInstruction=Inserisci il codice che abbiamo inviato al tuo dispositivo.
+smsAuthSentTo=Il codice è stato inviato a %1$s
+smsEnrollmentChangeNumber=Cambia numero di telefono
+smsEnrollmentCancel=Annulla
 
 smsAuthSmsNotSent=L''SMS non può essere inviato, a causa di {0}
 smsAuthCodeExpired=Il codice SMS è scaduto.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_nl.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_nl.properties
@@ -3,6 +3,9 @@ smsAuthText=Uw SMS-code is %1$s en is geldig voor %2$d minuten.
 smsAuthTitle=SMS-code
 smsAuthLabel=SMS-code
 smsAuthInstruction=Voer de code in die we naar uw apparaat hebben gestuurd.
+smsAuthSentTo=De code is verzonden naar %1$s
+smsEnrollmentChangeNumber=Telefoonnummer wijzigen
+smsEnrollmentCancel=Annuleren
 
 smsAuthSmsNotSent=De SMS kon niet worden verzonden vanwege {0}
 smsAuthCodeExpired=De SMS-code is verlopen.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_pl.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_pl.properties
@@ -3,6 +3,9 @@ smsAuthText=Twój kod SMS to %1$s i jest ważny przez %2$d minut.
 smsAuthTitle=Kod SMS
 smsAuthLabel=Kod SMS
 smsAuthInstruction=Wpisz kod SMS, który wysłaliśmy na twoje urządzenie.
+smsAuthSentTo=Kod wysłano na numer %1$s
+smsEnrollmentChangeNumber=Zmień numer telefonu
+smsEnrollmentCancel=Anuluj
 
 smsAuthSmsNotSent=Nie udało się wysłać SMS-a. Powód: {0}
 smsAuthCodeExpired=Kod SMS wygasł.

--- a/sms-authenticator/src/main/resources/theme-resources/templates/login-sms.ftl
+++ b/sms-authenticator/src/main/resources/theme-resources/templates/login-sms.ftl
@@ -3,6 +3,11 @@
 	<#if section = "header">
 		${msg("smsAuthTitle",realm.displayName)}
 	<#elseif section = "form">
+		<#if (smsAuthSentToText!)?has_content>
+		<div class="${properties.kcFormGroupClass!}" id="kc-sms-sent-hint">
+			<p class="pf-v5-c-helper-text" style="word-break: break-all;">${smsAuthSentToText}</p>
+		</div>
+		</#if>
 		<form onsubmit="login.disabled = true; return true;" id="kc-sms-code-login-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
 			<div class="${properties.kcFormGroupClass!}">
 				<div class="${properties.kcLabelWrapperClass!}">
@@ -13,17 +18,23 @@
 				</div>
 			</div>
 			<div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
-				<div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
-					<div class="${properties.kcFormOptionsWrapperClass!}">
-						<span><a href="/">${msg("backToApplication")?no_esc}</a></span>
-					</div>
-				</div>
-
 				<div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
 					<input name="login" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doSubmit")}"/>
 				</div>
 			</div>
 		</form>
+		<#if smsEnrollmentMode!false>
+		<div class="${properties.kcFormGroupClass!}" id="kc-sms-enrollment-actions" style="display:flex; flex-direction:column; gap:0.75rem; width:100%; max-width:100%; margin-top:0.75rem; box-sizing:border-box">
+			<form id="kc-sms-enrollment-change" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post" style="width:100%;">
+				<input type="hidden" name="sms_enrollment_action" value="change_number" />
+				<button type="submit" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}">${msg("smsEnrollmentChangeNumber")}</button>
+			</form>
+			<form id="kc-sms-enrollment-cancel" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post" style="width:100%;">
+				<input type="hidden" name="sms_enrollment_action" value="cancel" />
+				<button type="submit" class="${properties.kcButtonClass!} ${properties.kcButtonSecondaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}">${msg("smsEnrollmentCancel")}</button>
+			</form>
+		</div>
+		</#if>
 	<#elseif section = "info" >
 		${msg("smsAuthInstruction")}
 	</#if>

--- a/sms-authenticator/src/main/resources/theme-resources/templates/mobile_number_form.ftl
+++ b/sms-authenticator/src/main/resources/theme-resources/templates/mobile_number_form.ftl
@@ -18,17 +18,17 @@
 				</div>
 			</div>
 			<div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
-				<div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
-					<div class="${properties.kcFormOptionsWrapperClass!}">
-						<span><a href="/">${msg("backToApplication")?no_esc}</a></span>
-					</div>
-				</div>
-
 				<div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
 					<input name="phonenumber" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doSubmitMobile")}" />
 				</div>
 			</div>
 		</form>
+		<div class="${properties.kcFormGroupClass!}" id="kc-sms-enrollment-actions" style="display:flex; flex-direction:column; gap:0.75rem; width:100%; max-width:100%; margin-top:0.75rem; box-sizing:border-box">
+			<form id="kc-sms-enrollment-cancel" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post" style="width:100%;">
+				<input type="hidden" name="sms_enrollment_action" value="cancel" />
+				<button type="submit" class="${properties.kcButtonClass!} ${properties.kcButtonSecondaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}">${msg("smsEnrollmentCancel")}</button>
+			</form>
+		</div>
 	<#elseif section = "info" >
 		${msg("smsPhoneNumberInstructions")}
 	</#if>


### PR DESCRIPTION
Hello,

PhoneValidationRequiredAction no longer re-queues the “phone number” required action when the SMS validation step starts : the previous step already completed and removed that action from the user.
Re-adding it here made it hard to drop out of the flow, and left users stuck in enrollment.

fix #50 in my opinion