### PR TITLE
fix(sms): set countryList attribute when challenging after an invalid number was given

### DIFF
--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/PhoneNumberRequiredAction.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/PhoneNumberRequiredAction.java
@@ -299,6 +299,7 @@ public class PhoneNumberRequiredAction implements RequiredActionProvider, Creden
 		Response challenge = context
 			.form()
 			.setAttribute("mobileInputFieldPlaceholder", context.getAuthenticationSession().getAuthNote("mobileInputFieldPlaceholder"))
+			.setAttribute("countryList", getCountryCodeList(context))
 			.setError(formatError)
 			.createForm("mobile_number_form.ftl");
 		context.challenge(challenge);


### PR DESCRIPTION
Hello,

With the new country code selector, if the the phone number given is invalid and forceRetryOnBadFormat is true then the form does not list the country codes and the selector disappears.
I simply added the attribute using the existing method in this specific case.