### PR TITLE
#234 feat(email-authenticator): add email OTP authenticator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
       - run: |
           mkdir staging
           cp sms-authenticator/target/*.jar staging
+          cp email-authenticator/target/*.jar staging
           cp app-authenticator/target/*.jar staging
           cp enforce-mfa/target/*.jar staging
       - name: Create hash files

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 This repository contains the source code for a collection of Keycloak MFA plugins. The plugins are:
 * [SMS authenticator](sms-authenticator/README.md): Provides SMS as authentication step. SMS are sent via HTTP API, which can be configured. (production ready)
+* [Email authenticator](email-authenticator/README.md): Provides Email OTP as authentication step. Uses the SMTP server configured in the realm. (production ready)
 * [Enforce MFA](enforce-mfa/README.md): Force users to configure a second factor after logging in. (beta)
 * [Native App MFA integration](app-authenticator/README.md): connect a mobile app to Keycloak which receives a notification about a pending login process and allows the user to allow/block the login request. (work in progress)
 

--- a/email-authenticator/README.md
+++ b/email-authenticator/README.md
@@ -1,0 +1,42 @@
+# Keycloak Email Authenticator
+
+Keycloak Authentication Provider implementation that sends a one-time code (OTP) via email using the SMTP server configured in the Keycloak realm.
+
+# Installing
+1. Go to https://github.com/netzbegruenung/keycloak-mfa-plugins/releases and download the latest `netzbegruenung.email-authenticator-*.jar`.
+1. Copy the jar into the `providers` directory of your Keycloak:
+   ```shell
+   cp netzbegruenung.email-authenticator-*.jar /path/to/keycloak/providers
+   ```
+1. Run the `build` command and restart Keycloak:
+   ```shell
+   /path/to/keycloak/bin/kc.sh build [your-additional-flags]
+   systemctl restart keycloak.service
+   ```
+
+# Setup
+1. Log in to the Keycloak Admin Console and select your realm.
+1. Make sure the realm's **Email** settings point to a working SMTP server.
+1. Go to **Authentication** in the left sidebar and select the flow you want to use (e.g., `browser`).
+1. Since built-in flows are read-only, duplicate the flow if you haven't already: click the three dots in the top right of the flow details and select **Duplicate**.
+1. In your new flow, click **Add step**.
+1. Search for `Email Authentication (2FA)` and click **Add**.
+1. Set the requirement to `Alternative` (or `Required` to enforce it).
+1. Click the **Actions** menu (three dots) next to the `Email Authentication (2FA)` step and select **Config**. The following options are available:
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| Code length | Number of digits of the generated OTP. | `6` |
+| Time-to-live | Validity period of the OTP in seconds. | `300` |
+| Force 2FA | If no other 2FA method is configured, the user is forced to verify their email and use Email OTP. | `false` |
+
+The email subject and body are taken from the theme message bundle (keys `emailAuthSubject` and `emailAuthText`) and can be customised per realm/theme. The body supports `%1$s` (code) and `%2$d` (validity in minutes) placeholders.
+
+# Usage
+After the authenticator is wired into the flow, users with a verified email address automatically receive a login code on the second-factor step.
+
+# Enforce Email 2FA
+If the option `Force 2FA` is enabled and a user has no other 2FA method set up, Keycloak will add the built-in `VERIFY_EMAIL` required action so the user verifies their address before continuing.
+
+# License
+Apache License 2.0

--- a/email-authenticator/pom.xml
+++ b/email-authenticator/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>email-authenticator</artifactId>
+
+    <parent>
+        <groupId>netzbegruenung</groupId>
+        <artifactId>keycloak-mfa-tools</artifactId>
+        <version>26.5.8</version>
+    </parent>
+
+    <dependencies>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-core</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-server-spi</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-server-spi-private</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-services</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.logging</groupId>
+			<artifactId>jboss-logging</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.ws.rs</groupId>
+			<artifactId>jakarta.ws.rs-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.15.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.groupId}.${project.artifactId}-v${project.version}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/email-authenticator/pom.xml
+++ b/email-authenticator/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>netzbegruenung</groupId>
         <artifactId>keycloak-mfa-tools</artifactId>
-        <version>26.5.8</version>
+        <version>26.6.1</version>
     </parent>
 
     <dependencies>

--- a/email-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/EmailAuthenticator.java
+++ b/email-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/EmailAuthenticator.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2026 tech@spree GmbH
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @author Niko Köbler, https://www.n-k.de, @dasniko
+ * @author Netzbegruenung e.V.
+ * @author verdigado eG
+ * @author tech@spree GmbH
+ */
+
+package netzbegruenung.keycloak.authenticator;
+
+import org.jboss.logging.Logger;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.common.util.SecretGenerator;
+import org.keycloak.email.EmailException;
+import org.keycloak.email.EmailSenderProvider;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserModel.RequiredAction;
+import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.theme.Theme;
+
+import jakarta.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+
+public class EmailAuthenticator implements Authenticator {
+
+	private static final Logger logger = Logger.getLogger(EmailAuthenticator.class);
+	static final String TPL_CODE = "login-email.ftl";
+
+	@Override
+	public void authenticate(AuthenticationFlowContext context) {
+		AuthenticatorConfigModel config = context.getAuthenticatorConfig();
+		KeycloakSession session = context.getSession();
+		UserModel user = context.getUser();
+		RealmModel realm = context.getRealm();
+
+		Map<String, String> configMap = config != null ? config.getConfig() : Collections.emptyMap();
+
+		if (user.getEmail() == null || !user.isEmailVerified()) {
+			context.attempted();
+			return;
+		}
+
+		int length = Integer.parseInt(configMap.getOrDefault("length", "6"));
+		int ttl = Integer.parseInt(configMap.getOrDefault("ttl", "300"));
+
+		String code = SecretGenerator.getInstance().randomString(length, SecretGenerator.DIGITS);
+		AuthenticationSessionModel authSession = context.getAuthenticationSession();
+		authSession.setAuthNote("code", code);
+		authSession.setAuthNote("ttl", Long.toString(System.currentTimeMillis() + (ttl * 1000L)));
+
+		try {
+			Theme theme = session.theme().getTheme(Theme.Type.LOGIN);
+			Locale locale = session.getContext().resolveLocale(user);
+			String subjectTemplate = theme.getEnhancedMessages(realm, locale).getProperty("emailAuthSubject");
+			String bodyTemplate = theme.getEnhancedMessages(realm, locale).getProperty("emailAuthText");
+
+			String subject = String.format(subjectTemplate, code, Math.floorDiv(ttl, 60));
+			String body = String.format(bodyTemplate, code, Math.floorDiv(ttl, 60));
+
+			EmailSenderProvider emailSenderProvider = session.getProvider(EmailSenderProvider.class);
+			emailSenderProvider.send(realm.getSmtpConfig(), user, subject, body, body);
+
+			context.challenge(context.form().setAttribute("realm", realm).createForm(TPL_CODE));
+		} catch (EmailException | java.io.IOException e) {
+			logger.warn("Failed to send verification email", e);
+			context.failureChallenge(AuthenticationFlowError.INTERNAL_ERROR,
+				context.form().setError("emailAuthEmailNotSent", e.getMessage())
+					.createErrorPage(Response.Status.INTERNAL_SERVER_ERROR));
+		}
+	}
+
+	@Override
+	public void action(AuthenticationFlowContext context) {
+		String enteredCode = context.getHttpRequest().getDecodedFormParameters().getFirst("code");
+
+		AuthenticationSessionModel authSession = context.getAuthenticationSession();
+		String code = authSession.getAuthNote("code");
+		String ttl = authSession.getAuthNote("ttl");
+
+		if (code == null || ttl == null) {
+			context.failureChallenge(AuthenticationFlowError.INTERNAL_ERROR,
+				context.form().createErrorPage(Response.Status.INTERNAL_SERVER_ERROR));
+			return;
+		}
+
+		boolean isValid = code.equals(enteredCode);
+		if (isValid) {
+			if (Long.parseLong(ttl) < System.currentTimeMillis()) {
+				context.failureChallenge(AuthenticationFlowError.EXPIRED_CODE,
+					context.form().setError("emailAuthCodeExpired").createForm(TPL_CODE));
+			} else {
+				context.success();
+			}
+		} else {
+			AuthenticationExecutionModel execution = context.getExecution();
+			if (execution.isRequired()) {
+				context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS,
+					context.form().setAttribute("realm", context.getRealm())
+						.setError("emailAuthCodeInvalid").createForm(TPL_CODE));
+			} else if (execution.isConditional() || execution.isAlternative()) {
+				context.attempted();
+			}
+		}
+	}
+
+	@Override
+	public boolean requiresUser() {
+		return true;
+	}
+
+	@Override
+	public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+		return user.getEmail() != null && user.isEmailVerified();
+	}
+
+	@Override
+	public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+		if (user.getEmail() == null || !user.isEmailVerified()) {
+			user.addRequiredAction(RequiredAction.VERIFY_EMAIL);
+		}
+	}
+
+	@Override
+	public void close() {
+	}
+}

--- a/email-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/EmailAuthenticatorFactory.java
+++ b/email-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/EmailAuthenticatorFactory.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2026 tech@spree GmbH
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @author Netzbegruenung e.V.
+ * @author verdigado eG
+ * @author Niko Köbler, https://www.n-k.de, @dasniko
+ * @author tech@spree GmbH
+ */
+
+package netzbegruenung.keycloak.authenticator;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.List;
+
+public class EmailAuthenticatorFactory implements AuthenticatorFactory {
+
+	public static final String PROVIDER_ID = "email-otp-authenticator";
+	private static final EmailAuthenticator SINGLETON = new EmailAuthenticator();
+
+	private static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
+		AuthenticationExecutionModel.Requirement.REQUIRED,
+		AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+		AuthenticationExecutionModel.Requirement.DISABLED
+	};
+
+	@Override
+	public String getId() {
+		return PROVIDER_ID;
+	}
+
+	@Override
+	public Authenticator create(KeycloakSession session) {
+		return SINGLETON;
+	}
+
+	@Override
+	public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+		return REQUIREMENT_CHOICES;
+	}
+
+	@Override
+	public boolean isConfigurable() {
+		return true;
+	}
+
+	@Override
+	public boolean isUserSetupAllowed() {
+		return true;
+	}
+
+	@Override
+	public String getDisplayType() {
+		return "Email Authentication (2FA)";
+	}
+
+	@Override
+	public String getReferenceCategory() {
+		return "email-otp";
+	}
+
+	@Override
+	public String getHelpText() {
+		return "Validates an OTP sent via email to the user's verified address.";
+	}
+
+	@Override
+	public List<ProviderConfigProperty> getConfigProperties() {
+		return List.of(
+			new ProviderConfigProperty("length", "Code length", "The number of digits of the generated code.", ProviderConfigProperty.STRING_TYPE, "6"),
+			new ProviderConfigProperty("ttl", "Time-to-live", "The time in seconds the code is valid.", ProviderConfigProperty.STRING_TYPE, "300"),
+			new ProviderConfigProperty("forceSecondFactor", "Force 2FA", "If 2FA authentication is not configured, the user is forced to verify their email and use Email OTP.", ProviderConfigProperty.BOOLEAN_TYPE, false)
+		);
+	}
+
+	@Override
+	public void init(Config.Scope config) {
+	}
+
+	@Override
+	public void postInit(KeycloakSessionFactory factory) {
+	}
+
+	@Override
+	public void close() {
+	}
+}

--- a/email-authenticator/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/email-authenticator/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -1,0 +1,1 @@
+netzbegruenung.keycloak.authenticator.EmailAuthenticatorFactory

--- a/email-authenticator/src/main/resources/theme-resources/messages/messages_de.properties
+++ b/email-authenticator/src/main/resources/theme-resources/messages/messages_de.properties
@@ -1,0 +1,14 @@
+emailAuthSubject=Ihr Anmeldecode
+emailAuthText=Ihr E-Mail-Code lautet %1$s und ist %2$d Minuten gültig.
+
+emailAuthTitle=E-Mail-Code
+emailAuthLabel=E-Mail-Code
+emailAuthInstruction=Bitte geben Sie den Code ein, den wir an Ihre E-Mail-Adresse gesendet haben.
+
+emailAuthEmailNotSent=Die E-Mail konnte nicht gesendet werden. Grund: {0}
+emailAuthCodeExpired=Der E-Mail-Code ist abgelaufen.
+emailAuthCodeInvalid=Ungültiger E-Mail-Code, bitte erneut eingeben.
+
+emailAuthenticator=E-Mail-Authentifizierung
+
+email-otp-display-name=E-Mail-Authentifizierung

--- a/email-authenticator/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/email-authenticator/src/main/resources/theme-resources/messages/messages_en.properties
@@ -1,0 +1,14 @@
+emailAuthSubject=Your login code
+emailAuthText=Your email login code is %1$s and is valid for %2$d minutes.
+
+emailAuthTitle=Email Code
+emailAuthLabel=Email Code
+emailAuthInstruction=Enter the code we sent to your email address.
+
+emailAuthEmailNotSent=The email could not be sent: {0}
+emailAuthCodeExpired=The email code has expired.
+emailAuthCodeInvalid=Invalid email code entered, please enter it again.
+
+emailAuthenticator=Email Authenticator
+
+email-otp-display-name=Email Authenticator

--- a/email-authenticator/src/main/resources/theme-resources/messages/messages_fr.properties
+++ b/email-authenticator/src/main/resources/theme-resources/messages/messages_fr.properties
@@ -1,0 +1,14 @@
+emailAuthSubject=Votre code de connexion
+emailAuthText=Votre code de connexion par e-mail est %1$s et est valable pendant %2$d minutes.
+
+emailAuthTitle=Code e-mail
+emailAuthLabel=Code e-mail
+emailAuthInstruction=Saisissez le code que nous avons envoyé à votre adresse e-mail.
+
+emailAuthEmailNotSent=L'e-mail n'a pas pu être envoyé : {0}
+emailAuthCodeExpired=Le code e-mail a expiré.
+emailAuthCodeInvalid=Code e-mail invalide, veuillez le saisir à nouveau.
+
+emailAuthenticator=Authentification par e-mail
+
+email-otp-display-name=Authentification par e-mail

--- a/email-authenticator/src/main/resources/theme-resources/messages/messages_nl.properties
+++ b/email-authenticator/src/main/resources/theme-resources/messages/messages_nl.properties
@@ -1,0 +1,14 @@
+emailAuthSubject=Uw inlogcode
+emailAuthText=Uw e-mail-inlogcode is %1$s en is %2$d minuten geldig.
+
+emailAuthTitle=E-mailcode
+emailAuthLabel=E-mailcode
+emailAuthInstruction=Voer de code in die we naar uw e-mailadres hebben gestuurd.
+
+emailAuthEmailNotSent=De e-mail kon niet worden verzonden: {0}
+emailAuthCodeExpired=De e-mailcode is verlopen.
+emailAuthCodeInvalid=Ongeldige e-mailcode, voer de code opnieuw in.
+
+emailAuthenticator=E-mailauthenticatie
+
+email-otp-display-name=E-mailauthenticatie

--- a/email-authenticator/src/main/resources/theme-resources/templates/login-email.ftl
+++ b/email-authenticator/src/main/resources/theme-resources/templates/login-email.ftl
@@ -1,0 +1,30 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayInfo=true; section>
+	<#if section = "header">
+		${msg("emailAuthTitle",realm.displayName)}
+	<#elseif section = "form">
+		<form onsubmit="login.disabled = true; return true;" id="kc-email-code-login-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
+			<div class="${properties.kcFormGroupClass!}">
+				<div class="${properties.kcLabelWrapperClass!}">
+					<label for="code" class="${properties.kcLabelClass!}">${msg("emailAuthLabel")}</label>
+				</div>
+				<div class="${properties.kcInputWrapperClass!}">
+					<input type="number" min="0" inputmode="numeric" pattern="[0-9]*" id="code" name="code" class="${properties.kcInputClass!}" autocomplete="off" autofocus />
+				</div>
+			</div>
+			<div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
+				<div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
+					<div class="${properties.kcFormOptionsWrapperClass!}">
+						<span><a href="/">${msg("backToApplication")?no_esc}</a></span>
+					</div>
+				</div>
+
+				<div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
+					<input name="login" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doSubmit")}"/>
+				</div>
+			</div>
+		</form>
+	<#elseif section = "info" >
+		${msg("emailAuthInstruction")}
+	</#if>
+</@layout.registrationLayout>

--- a/email-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/EmailAuthenticatorTest.java
+++ b/email-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/EmailAuthenticatorTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 tech@spree GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package netzbegruenung.keycloak.authenticator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.email.EmailException;
+import org.keycloak.email.EmailSenderProvider;
+import org.keycloak.forms.login.LoginFormsProvider;
+import org.keycloak.http.HttpRequest;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.KeycloakContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.ThemeManager;
+import org.keycloak.models.UserModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.theme.Theme;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.matches;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class EmailAuthenticatorTest {
+
+	private EmailAuthenticator authenticator;
+	private AuthenticationFlowContext context;
+	private AuthenticationSessionModel authSession;
+	private HttpRequest request;
+	private LoginFormsProvider form;
+	private RealmModel realm;
+	private KeycloakSession session;
+	private KeycloakContext keycloakContext;
+	private UserModel user;
+	private EmailSenderProvider emailSenderProvider;
+
+	@BeforeEach
+	public void setup() throws Exception {
+		authenticator = new EmailAuthenticator();
+		context = mock(AuthenticationFlowContext.class);
+		authSession = mock(AuthenticationSessionModel.class);
+		request = mock(HttpRequest.class);
+		form = mock(LoginFormsProvider.class);
+		realm = mock(RealmModel.class);
+		session = mock(KeycloakSession.class);
+		keycloakContext = mock(KeycloakContext.class);
+		user = mock(UserModel.class);
+		emailSenderProvider = mock(EmailSenderProvider.class);
+
+		when(context.getAuthenticationSession()).thenReturn(authSession);
+		when(context.getHttpRequest()).thenReturn(request);
+		when(context.form()).thenReturn(form);
+		when(context.getRealm()).thenReturn(realm);
+		when(context.getSession()).thenReturn(session);
+		when(context.getUser()).thenReturn(user);
+
+		when(session.getProvider(EmailSenderProvider.class)).thenReturn(emailSenderProvider);
+		when(session.getContext()).thenReturn(keycloakContext);
+		when(keycloakContext.resolveLocale(user)).thenReturn(Locale.ENGLISH);
+
+		ThemeManager themeManager = mock(ThemeManager.class);
+		Theme theme = mock(Theme.class);
+		when(session.theme()).thenReturn(themeManager);
+		when(themeManager.getTheme(Theme.Type.LOGIN)).thenReturn(theme);
+		Properties messages = new Properties();
+		messages.setProperty("emailAuthSubject", "Your login code");
+		messages.setProperty("emailAuthText", "Code: %1$s valid %2$d min");
+		when(theme.getEnhancedMessages(eq(realm), any(Locale.class))).thenReturn(messages);
+
+		when(user.getEmail()).thenReturn("test@example.com");
+		when(user.isEmailVerified()).thenReturn(true);
+
+		when(form.setAttribute(anyString(), any())).thenReturn(form);
+		when(form.setError(anyString(), any())).thenReturn(form);
+		when(form.setError(anyString(), (Object[]) any())).thenReturn(form);
+		when(form.setError(anyString())).thenReturn(form);
+		when(form.createForm(anyString())).thenReturn(mock(Response.class));
+	}
+
+	@Test
+	public void testAction_Success() {
+		when(authSession.getAuthNote("code")).thenReturn("123456");
+		when(authSession.getAuthNote("ttl")).thenReturn(String.valueOf(System.currentTimeMillis() + 60000));
+
+		MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+		params.add("code", "123456");
+		when(request.getDecodedFormParameters()).thenReturn(params);
+
+		authenticator.action(context);
+
+		verify(context).success();
+	}
+
+	@Test
+	public void testAction_InvalidCode() {
+		AuthenticationExecutionModel execution = mock(AuthenticationExecutionModel.class);
+		when(context.getExecution()).thenReturn(execution);
+		when(execution.isRequired()).thenReturn(true);
+
+		when(authSession.getAuthNote("code")).thenReturn("123456");
+		when(authSession.getAuthNote("ttl")).thenReturn(String.valueOf(System.currentTimeMillis() + 60000));
+
+		MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+		params.add("code", "654321");
+		when(request.getDecodedFormParameters()).thenReturn(params);
+
+		authenticator.action(context);
+
+		verify(context).failureChallenge(eq(AuthenticationFlowError.INVALID_CREDENTIALS), any());
+	}
+
+	@Test
+	public void testAction_ExpiredCode() {
+		when(authSession.getAuthNote("code")).thenReturn("123456");
+		when(authSession.getAuthNote("ttl")).thenReturn(String.valueOf(System.currentTimeMillis() - 1000));
+
+		MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+		params.add("code", "123456");
+		when(request.getDecodedFormParameters()).thenReturn(params);
+
+		authenticator.action(context);
+
+		verify(context).failureChallenge(eq(AuthenticationFlowError.EXPIRED_CODE), any());
+	}
+
+	@Test
+	public void testAuthenticate_SendsEmail() throws EmailException {
+		AuthenticatorConfigModel config = new AuthenticatorConfigModel();
+		Map<String, String> configMap = new HashMap<>();
+		configMap.put("length", "6");
+		configMap.put("ttl", "300");
+		config.setConfig(configMap);
+
+		when(context.getAuthenticatorConfig()).thenReturn(config);
+
+		authenticator.authenticate(context);
+
+		verify(emailSenderProvider).send(any(), eq(user), eq("Your login code"), matches("Code: \\d{6} valid 5 min"), matches("Code: \\d{6} valid 5 min"));
+	}
+}

--- a/mfa-dev-runner/README.md
+++ b/mfa-dev-runner/README.md
@@ -7,7 +7,7 @@ This module is a development utility designed to streamline the development of t
 The `mfa-dev-runner` module leverages the Keycloak Quarkus extension (`keycloak-quarkus-server`) to run Keycloak as a Quarkus application in development mode.
 
 Its `pom.xml` is configured to:
-1.  Include the `sms-authenticator`, `app-authenticator`, and `enforce-mfa` modules as dependencies.
+1.  Include the `sms-authenticator`, `email-authenticator`, `app-authenticator`, and `enforce-mfa` modules as dependencies.
 2.  Include the `keycloak-quarkus-server` dependency.
 3.  Configure the `quarkus-maven-plugin` to launch the Keycloak server.
 

--- a/mfa-dev-runner/pom.xml
+++ b/mfa-dev-runner/pom.xml
@@ -17,6 +17,11 @@
 		</dependency>
 		<dependency>
 			<groupId>netzbegruenung</groupId>
+			<artifactId>email-authenticator</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>netzbegruenung</groupId>
 			<artifactId>app-authenticator</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
 
 	<modules>
 		<module>sms-authenticator</module>
+		<module>email-authenticator</module>
         <module>app-authenticator</module>
 		<module>enforce-mfa</module>
 		<module>mfa-dev-runner</module>


### PR DESCRIPTION
## What changed

Adds a new `email-authenticator` module that provides an Email OTP authentication step for Keycloak. The authenticator sends a one-time code using the realm SMTP configuration and renders a dedicated login form for code entry.

## Why

This adds email-based MFA as an alternative second factor alongside the existing MFA plugins. It supports users with verified email addresses and can optionally force email verification when no other second factor is configured.