### PR TITLE
feat(sms): resolve sms registration from required actions, with legacy sms-2fa support

### DIFF
--- a/sms-authenticator/README.md
+++ b/sms-authenticator/README.md
@@ -23,8 +23,8 @@ from the original authenticator provider [documentation](https://www.keycloak.or
 1. Go to `/admin/master/console/#/realm/authentication/required-actions` and enable required actions "Phone Validation" and "Update Mobile Number"
 1. Navigate to your Authentication flow configuration: https://keycloak.example.com/admin/master/console/#/YOUR-REALM/authentication. Then edit the `Browser flow`.
 1. Add a new step next to the `OTP Form` step. Choose the `SMS Authentication (2FA)` authenticator and set it to `Alternative`.
-1. Make sure that you name the Alias `sms-2fa`. This is currently a hack that will hopefully be fixed. Additional executions with other names can be added. But this first execution will be used for the confirmation SMS when setting up a new phone number.
-1. Go into the config of the execution and configure the plugin so that it works with the API of your SMS proivder HTTP API. The data is always sent in a HTTP POST request. Refer to the API documentation of your provider to choose the correct configuration values. The details of the request can be configured with the following configuration options:
+1. Prefer configuring SMS on the required action "Update Mobile Number" (gear / settings). That config is used for phone registration SMS and as the default for login SMS. Legacy: you can still use an authenticator config with alias `sms-2fa`; if the required-action SMS API URL and Simulation mode settings are left empty/untouched, registration still uses `sms-2fa`. Optionally, a config on the SMS Authentication (2FA) execution can override settings for login only. On the required action, Simulation mode defaults to off (the authenticator execution still defaults to on).
+1. Configure the plugin so that it works with the API of your SMS proivder HTTP API. The data is always sent in a HTTP POST request. Refer to the API documentation of your provider to choose the correct configuration values. The details of the request can be configured with the following configuration options:
    1. `SMS API URL`: the URL to which the HTTP POST request should be sent.
    1. `URL encode data`: When off, the data will be sent as an `application/json` body. When on, the data will be encoded as URL parameters.
    1. `Put API Secret Token in Authorization Header`: If set, API Secret will be sent as Authorization Header, 'API Secret Token Attribute' and 'Basic Auth Username' will be ignored.
@@ -44,7 +44,7 @@ After successfully configured the authenticator and the required actions users c
 account console `/realms/realm/account/#/account-security/signing-in` by entering and confirming their phone number.
 
 # Enforce SMS 2FA
-If the option `Force 2FA` in the SMS Authenticator config is enabled and a user has no other 2FA method already enabled,
+If the option `Force 2FA` in the SMS config (on the required action or the authenticator/`sms-2fa` config) is enabled and a user has no other 2FA method already enabled,
 users will have to set up the SMS Authenticator.
 
 # Testing

--- a/sms-authenticator/pom.xml
+++ b/sms-authenticator/pom.xml
@@ -91,6 +91,22 @@
 			<version>${keycloak.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>5.15.2</version>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
 
     <build>

--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/PhoneNumberRequiredAction.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/PhoneNumberRequiredAction.java
@@ -35,7 +35,6 @@ import org.keycloak.authentication.RequiredActionProvider;
 import org.keycloak.authentication.requiredactions.WebAuthnRegisterFactory;
 import org.keycloak.credential.CredentialModel;
 import org.keycloak.credential.CredentialProvider;
-import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
@@ -68,21 +67,23 @@ public class PhoneNumberRequiredAction implements RequiredActionProvider, Creden
 
 	@Override
 	public void evaluateTriggers(RequiredActionContext context) {
-		// TODO: get the alias from somewhere else or move config into realm or application scope
-		AuthenticatorConfigModel config = context.getRealm().getAuthenticatorConfigByAlias("sms-2fa");
-		if (config == null) {
-			logger.error("Failed to check 2FA enforcement, no config alias sms-2fa found");
+		Map<String, String> config = SmsRegistrationConfigResolver.getMergedRegistrationConfig(context.getRealm());
+		if (config.isEmpty()) {
+			logger.errorf(
+				"Failed to check 2FA enforcement, no SMS registration configuration (legacy alias %s). "
+					+ "Use required action \"Update Mobile Number\" (gear) for inline SMS settings, or create an authenticator config with that alias on your SMS flow step.",
+				SmsRegistrationConfigResolver.LEGACY_DEFAULT_ALIAS
+			);
 			return;
 		}
-
 		// Auto-enroll: if enableByDefault is active and user has the mobile number attribute,
 		// create the SMS credential automatically so 2FA is enforced from the next login onwards.
-		boolean enableByDefault = Boolean.parseBoolean(config.getConfig().getOrDefault("enableByDefault", "false"));
+		boolean enableByDefault = Boolean.parseBoolean(config.getOrDefault("enableByDefault", "false"));
 		if (enableByDefault) {
 			boolean hasCredential = context.getUser().credentialManager()
 				.getStoredCredentialsByTypeStream(SmsAuthCredentialModel.TYPE).findAny().isPresent();
 			if (!hasCredential) {
-				String mobileNumberAttribute = config.getConfig().getOrDefault("mobileNumberAttribute", "mobile_number");
+				String mobileNumberAttribute = config.getOrDefault("mobileNumberAttribute", "mobile_number");
 				String mobileNumber = context.getUser().getAttributeStream(mobileNumberAttribute)
 					.filter(n -> n != null && !n.isBlank()).findFirst().orElse(null);
 				if (mobileNumber != null) {
@@ -96,14 +97,14 @@ public class PhoneNumberRequiredAction implements RequiredActionProvider, Creden
 			}
 		}
 
-		boolean forceSecondFactorEnabled = Boolean.parseBoolean(config.getConfig().get("forceSecondFactor"));
+		boolean forceSecondFactorEnabled = Boolean.parseBoolean(config.get("forceSecondFactor"));
 		if (forceSecondFactorEnabled) {
-			if (config.getConfig().get("whitelist") != null) {
-				RoleModel whitelistRole = context.getRealm().getRole(config.getConfig().get("whitelist"));
+			if (config.get("whitelist") != null) {
+				RoleModel whitelistRole = context.getRealm().getRole(config.get("whitelist"));
 				if (whitelistRole == null) {
 					logger.errorf(
 						"Failed configured whitelist role check [%s], make sure that the role exists",
-						config.getConfig().get("whitelist")
+						config.get("whitelist")
 					);
 				} else if (context.getUser().hasRole(whitelistRole)) {
 					// skip enforcement if user is whitelisted
@@ -112,7 +113,7 @@ public class PhoneNumberRequiredAction implements RequiredActionProvider, Creden
 			}
 			// add auth note for phone number input placeholder
 			context.getAuthenticationSession().setAuthNote("mobileInputFieldPlaceholder",
-				config.getConfig().getOrDefault("mobileInputFieldPlaceholder", ""));
+				config.getOrDefault("mobileInputFieldPlaceholder", ""));
 
 			// list of accepted 2FA alternatives
 			List<String> secondFactors = Arrays.asList(
@@ -161,8 +162,8 @@ public class PhoneNumberRequiredAction implements RequiredActionProvider, Creden
 	 * @return a list of maps containing country name, code, and emoji
 	 */
 	public List<Map<String, String>> getCountryCodeList(RequiredActionContext context) {
-		AuthenticatorConfigModel config = context.getRealm().getAuthenticatorConfigByAlias("sms-2fa");
-		String countryCodeList = config.getConfig().getOrDefault("countryCodeList", "");
+		Map<String, String> config = SmsRegistrationConfigResolver.getMergedRegistrationConfig(context.getRealm());
+		String countryCodeList = config.getOrDefault("countryCodeList", "");
 
 		UserModel user = context.getUser();
 		KeycloakSession session = context.getSession();
@@ -216,17 +217,11 @@ public class PhoneNumberRequiredAction implements RequiredActionProvider, Creden
 		}
 
 		// get the phone number formatting values from the config
-		AuthenticatorConfigModel config = context.getRealm().getAuthenticatorConfigByAlias("sms-2fa");
-		boolean normalizeNumber = false;
-		boolean forceRetryOnBadFormat = false;
-		boolean enforcePhoneNumberUniqueness = true;
-		boolean storeInAttribute = false;
-		if (config != null && config.getConfig() != null) {
-			normalizeNumber = Boolean.parseBoolean(config.getConfig().getOrDefault("normalizePhoneNumber", "false"));
-			forceRetryOnBadFormat = Boolean.parseBoolean(config.getConfig().getOrDefault("forceRetryOnBadFormat", "false"));
-			enforcePhoneNumberUniqueness = Boolean.parseBoolean(config.getConfig().getOrDefault("enforcePhoneNumberUniqueness", "false"));
-			storeInAttribute = Boolean.parseBoolean(config.getConfig().getOrDefault("storeInAttribute", "false"));
-		}
+		Map<String, String> config = SmsRegistrationConfigResolver.getMergedRegistrationConfig(context.getRealm());
+		boolean normalizeNumber = Boolean.parseBoolean(config.getOrDefault("normalizePhoneNumber", "false"));
+		boolean forceRetryOnBadFormat = Boolean.parseBoolean(config.getOrDefault("forceRetryOnBadFormat", "false"));
+		boolean enforcePhoneNumberUniqueness = Boolean.parseBoolean(config.getOrDefault("enforcePhoneNumberUniqueness", "false"));
+		boolean storeInAttribute = Boolean.parseBoolean(config.getOrDefault("storeInAttribute", "false"));
 
 		// try to format the phone number
 		if (normalizeNumber) {
@@ -268,16 +263,19 @@ public class PhoneNumberRequiredAction implements RequiredActionProvider, Creden
 	 * @return				the formatted mobile phone number, null if the phone number is invalid or mobileNumber if the config was not found
 	 */
 	private String formatPhoneNumber(RequiredActionContext context, String mobileNumber) {
-		AuthenticatorConfigModel config = context.getRealm().getAuthenticatorConfigByAlias("sms-2fa");
-		if (config == null || config.getConfig() == null) {
-			logger.error("Failed format phone number, no config alias sms-2fa found");
+		Map<String, String> config = SmsRegistrationConfigResolver.getMergedRegistrationConfig(context.getRealm());
+		if (config.isEmpty()) {
+			logger.errorf(
+				"Failed format phone number, no SMS registration configuration (legacy alias %s)",
+				SmsRegistrationConfigResolver.LEGACY_DEFAULT_ALIAS
+			);
 			return mobileNumber;
 		}
 		final PhoneNumberUtil phoneNumberUtil = PhoneNumberUtil.getInstance();
 		int countryNumber;
 		// try to get the country code from the country number in the config, fallback on default DE
 		try {
-			countryNumber = Integer.parseInt(whitespacePattern.matcher(config.getConfig()
+			countryNumber = Integer.parseInt(whitespacePattern.matcher(config
 				.getOrDefault("countrycode", "49").replace("+", ""))
 				.replaceAll(""));
 		} catch (NumberFormatException e) {
@@ -307,7 +305,7 @@ public class PhoneNumberRequiredAction implements RequiredActionProvider, Creden
 		List<PhoneNumberUtil.PhoneNumberType> numberTypeFilters = new ArrayList<>();
 		String numberFiltersString = null;
 		try {
-			numberFiltersString = config.getConfig().getOrDefault("numberTypeFilters", "");
+			numberFiltersString = config.getOrDefault("numberTypeFilters", "");
 			if (!numberFiltersString.isBlank()) {
 				numberFilterSplitter.splitToStream(numberFiltersString).forEach(filterString ->
 					numberTypeFilters.add(PhoneNumberUtil.PhoneNumberType.valueOf(filterString)));

--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/PhoneNumberRequiredActionFactory.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/PhoneNumberRequiredActionFactory.java
@@ -24,8 +24,15 @@ package netzbegruenung.keycloak.authenticator;
 import org.keycloak.Config;
 import org.keycloak.authentication.RequiredActionFactory;
 import org.keycloak.authentication.RequiredActionProvider;
+import org.keycloak.component.ComponentValidationException;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RequiredActionConfigModel;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -33,36 +40,71 @@ import org.keycloak.models.KeycloakSessionFactory;
  */
 public class PhoneNumberRequiredActionFactory implements RequiredActionFactory {
 
-    private static final PhoneNumberRequiredAction SINGLETON = new PhoneNumberRequiredAction();
+	private static final PhoneNumberRequiredAction SINGLETON = new PhoneNumberRequiredAction();
 
-    @Override
-    public RequiredActionProvider create(KeycloakSession session) {
-        return SINGLETON;
-    }
+	@Override
+	public RequiredActionProvider create(KeycloakSession session) {
+		return SINGLETON;
+	}
 
-    @Override
-    public String getId() {
-        return PhoneNumberRequiredAction.PROVIDER_ID;
-    }
+	@Override
+	public String getId() {
+		return PhoneNumberRequiredAction.PROVIDER_ID;
+	}
 
-    @Override
-    public String getDisplayText() {
-        return "Update Mobile Number";
-    }
+	@Override
+	public String getDisplayText() {
+		return "Update Mobile Number";
+	}
 
-    @Override
-    public void init(Config.Scope config) {
+	@Override
+	public boolean isConfigurable() {
+		return true;
+	}
 
-    }
+	@Override
+	public List<ProviderConfigProperty> getConfigMetadata() {
+		return SmsAuthenticatorFactory.getSmsRequiredActionConfigProperties();
+	}
 
-    @Override
-    public void postInit(KeycloakSessionFactory factory) {
+	@Override
+	public void validateConfig(KeycloakSession session, RealmModel realm, RequiredActionConfigModel config) {
+		if (config == null || config.getConfig() == null) {
+			return;
+		}
+		Map<String, String> raw = config.getConfig();
+		if (!SmsRegistrationConfigResolver.isInlineSmsRegistration(raw)
+			&& !(raw.containsKey("apiurl") && raw.containsKey("simulation"))) {
+			return;
+		}
+		Map<String, String> effective = SmsRegistrationConfigResolver.materializeInlineRegistrationConfig(raw);
+		if (!Boolean.parseBoolean(effective.get("simulation"))) {
+			String url = effective.get("apiurl");
+			if (url == null || url.isBlank()) {
+				throw new ComponentValidationException("SMS API URL is required unless simulation mode is enabled.");
+			}
+		}
+		try {
+			Integer.parseInt(effective.get("length").trim());
+			Integer.parseInt(effective.get("ttl").trim());
+		} catch (NumberFormatException e) {
+			throw new ComponentValidationException("Code length and TTL must be integers.");
+		}
+	}
 
-    }
+	@Override
+	public void init(Config.Scope config) {
 
-    @Override
-    public void close() {
+	}
 
-    }
+	@Override
+	public void postInit(KeycloakSessionFactory factory) {
+
+	}
+
+	@Override
+	public void close() {
+
+	}
 
 }

--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/PhoneValidationRequiredAction.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/PhoneValidationRequiredAction.java
@@ -31,7 +31,6 @@ import org.keycloak.authentication.RequiredActionContext;
 import org.keycloak.authentication.RequiredActionProvider;
 import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.credential.CredentialProvider;
-import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserCredentialModel;
@@ -40,6 +39,7 @@ import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.theme.Theme;
 
 import java.util.Locale;
+import java.util.Map;
 import jakarta.ws.rs.core.Response;
 
 public class PhoneValidationRequiredAction implements RequiredActionProvider, CredentialRegistrator {
@@ -58,14 +58,32 @@ public class PhoneValidationRequiredAction implements RequiredActionProvider, Cr
 			RealmModel realm = context.getRealm();
 
 			AuthenticationSessionModel authSession = context.getAuthenticationSession();
-			// TODO: get the alias from somewhere else or move config into realm or application scope
-			AuthenticatorConfigModel config = context.getRealm().getAuthenticatorConfigByAlias("sms-2fa");
+			Map<String, String> config = SmsRegistrationConfigResolver.getMergedRegistrationConfig(realm);
+			if (config.isEmpty()) {
+				logger.errorf(
+					"Phone validation failed, no SMS registration configuration (legacy alias %s). "
+						+ "Use required action \"Update Mobile Number\" (gear) for inline SMS settings, or create an authenticator config with that alias on your SMS flow step.",
+					SmsRegistrationConfigResolver.LEGACY_DEFAULT_ALIAS
+				);
+				context.failure();
+				return;
+			}
 
 			String mobileNumber = authSession.getAuthNote("mobile_number");
 			logger.infof("Validating phone number: %s of user: %s", mobileNumber, user.getUsername());
 
-			int length = Integer.parseInt(config.getConfig().get("length"));
-			int ttl = Integer.parseInt(config.getConfig().get("ttl"));
+			String lenStr = config.getOrDefault("length", SmsRegistrationConfigResolver.DEFAULT_LENGTH).trim();
+			String ttlStr = config.getOrDefault("ttl", SmsRegistrationConfigResolver.DEFAULT_TTL_SECONDS).trim();
+			int length;
+			int ttl;
+			try {
+				length = Integer.parseInt(lenStr);
+				ttl = Integer.parseInt(ttlStr);
+			} catch (NumberFormatException e) {
+				logger.errorf("Invalid SMS registration length or ttl (length=%s ttl=%s)", lenStr, ttlStr, e);
+				context.failure();
+				return;
+			}
 
 			String code = SecretGenerator.getInstance().randomString(length, SecretGenerator.DIGITS);
 			authSession.setAuthNote("code", code);
@@ -76,7 +94,8 @@ public class PhoneValidationRequiredAction implements RequiredActionProvider, Cr
 			String smsAuthText = theme.getEnhancedMessages(realm,locale).getProperty("smsAuthText");
 			String smsText = String.format(smsAuthText, code, Math.floorDiv(ttl, 60));
 
-			SmsServiceFactory.get(config.getConfig()).send(mobileNumber, smsText);
+			SmsRegistrationConfigResolver.logWarningIfUsingLegacySmsAuthenticatorConfig(realm);
+			SmsServiceFactory.get(config).send(mobileNumber, smsText);
 
 			Response challenge = context.form()
 				.setAttribute("realm", realm)
@@ -126,13 +145,11 @@ public class PhoneValidationRequiredAction implements RequiredActionProvider, Cr
 	}
 
 	private void handlePhoneToAttribute(RequiredActionContext context, String mobileNumber) {
-		AuthenticatorConfigModel config = context.getRealm().getAuthenticatorConfigByAlias("sms-2fa");
-		if (config == null) {
-			logger.warn("No config alias sms-2fa found, skip phone number to attribute check");
-		} else {
-			if (Boolean.parseBoolean(config.getConfig().get("storeInAttribute"))) {
-				context.getUser().setSingleAttribute("mobile_number", mobileNumber);
-			}
+		Map<String, String> config = SmsRegistrationConfigResolver.getMergedRegistrationConfig(context.getRealm());
+		if (config.isEmpty()) {
+			logger.warn("No SMS registration configuration, skip phone number to attribute check");
+		} else if (Boolean.parseBoolean(config.getOrDefault("storeInAttribute", "false"))) {
+			context.getUser().setSingleAttribute("mobile_number", mobileNumber);
 		}
 	}
 

--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticator.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticator.java
@@ -36,8 +36,6 @@ import org.keycloak.authentication.RequiredActionProvider;
 import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.credential.CredentialModel;
 import org.keycloak.credential.CredentialProvider;
-import org.keycloak.models.AuthenticationExecutionModel;
-import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
@@ -46,11 +44,12 @@ import org.keycloak.theme.Theme;
 import org.keycloak.util.JsonSerialization;
 
 import jakarta.ws.rs.core.Response;
-import java.util.Locale;
-import java.util.Optional;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
 
 public class SmsAuthenticator implements Authenticator, CredentialValidator<SmsAuthCredentialProvider> {
 
@@ -59,10 +58,14 @@ public class SmsAuthenticator implements Authenticator, CredentialValidator<SmsA
 
 	@Override
 	public void authenticate(AuthenticationFlowContext context) {
-		AuthenticatorConfigModel config = context.getAuthenticatorConfig();
+		RealmModel realm = context.getRealm();
 		KeycloakSession session = context.getSession();
 		UserModel user = context.getUser();
-		RealmModel realm = context.getRealm();
+
+		Map<String, String> cfg = SmsRegistrationConfigResolver.getEffectiveSmsConfigForExecution(
+			realm,
+			context.getAuthenticatorConfig()
+		);
 
 		Optional<CredentialModel> model = context.getUser().credentialManager().getStoredCredentialsByTypeStream(SmsAuthCredentialModel.TYPE).findFirst();
 		String mobileNumber;
@@ -75,9 +78,9 @@ public class SmsAuthenticator implements Authenticator, CredentialValidator<SmsA
 
 		// When storeInAttribute is active, the attribute is the source of truth
 		// Allows admins to update the number without requiring the user to re-enroll.
-		boolean storeInAttribute = Boolean.parseBoolean(config.getConfig().getOrDefault("storeInAttribute", "false"));
+		boolean storeInAttribute = Boolean.parseBoolean(cfg.getOrDefault("storeInAttribute", "false"));
 		if (storeInAttribute) {
-			String mobileNumberAttribute = config.getConfig().getOrDefault("mobileNumberAttribute", "mobile_number");
+			String mobileNumberAttribute = cfg.getOrDefault("mobileNumberAttribute", "mobile_number");
 			String attributeNumber = user.getAttributeStream(mobileNumberAttribute)
 				.filter(n -> n != null && !n.isBlank())
 				.findFirst()
@@ -90,8 +93,27 @@ public class SmsAuthenticator implements Authenticator, CredentialValidator<SmsA
 			}
 		}
 
-		int length = Integer.parseInt(config.getConfig().get("length"));
-		int ttl = Integer.parseInt(config.getConfig().get("ttl"));
+		String lenStr = cfg.get("length");
+		String ttlStr = cfg.get("ttl");
+		if (lenStr == null || lenStr.isBlank() || ttlStr == null || ttlStr.isBlank()) {
+			logger.errorf("SMS authenticator: missing length or ttl in effective config (realm %s). Configure the execution or global SMS on required action \"Update Mobile Number\".", realm.getName());
+			context.failureChallenge(AuthenticationFlowError.INTERNAL_ERROR,
+				context.form().setError("smsAuthSmsNotSent", "Error. Use another method.")
+					.createErrorPage(Response.Status.INTERNAL_SERVER_ERROR));
+			return;
+		}
+		int length;
+		int ttl;
+		try {
+			length = Integer.parseInt(lenStr.trim());
+			ttl = Integer.parseInt(ttlStr.trim());
+		} catch (NumberFormatException e) {
+			logger.error("SMS authenticator: invalid length or ttl", e);
+			context.failureChallenge(AuthenticationFlowError.INTERNAL_ERROR,
+				context.form().setError("smsAuthSmsNotSent", "Error. Use another method.")
+					.createErrorPage(Response.Status.INTERNAL_SERVER_ERROR));
+			return;
+		}
 
 		String code = SecretGenerator.getInstance().randomString(length, SecretGenerator.DIGITS);
 		AuthenticationSessionModel authSession = context.getAuthenticationSession();
@@ -101,10 +123,11 @@ public class SmsAuthenticator implements Authenticator, CredentialValidator<SmsA
 		try {
 			Theme theme = session.theme().getTheme(Theme.Type.LOGIN);
 			Locale locale = session.getContext().resolveLocale(user);
-			String smsAuthText = theme.getEnhancedMessages(realm,locale).getProperty("smsAuthText");
+			String smsAuthText = theme.getEnhancedMessages(realm, locale).getProperty("smsAuthText");
 			String smsText = String.format(smsAuthText, code, Math.floorDiv(ttl, 60));
 
-			SmsServiceFactory.get(config.getConfig()).send(mobileNumber, smsText);
+			SmsRegistrationConfigResolver.logWarningIfUsingLegacySmsAuthenticatorConfig(realm);
+			SmsServiceFactory.get(cfg).send(mobileNumber, smsText);
 
 			context.challenge(context.form()
 				.setAttribute("realm", realm)

--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorFactory.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorFactory.java
@@ -30,6 +30,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.provider.ProviderConfigProperty;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -37,6 +38,91 @@ public class SmsAuthenticatorFactory implements AuthenticatorFactory {
 
 	public static final String PROVIDER_ID = "mobile-number-authenticator";
 	private static final SmsAuthenticator SINGLETON = new SmsAuthenticator();
+
+	// Shared authenticator/RA property list for legacy sms-2fa compatibility; split later (see getters).
+	private static final List<ProviderConfigProperty> SMS_AUTHENTICATOR_CONFIG_PROPERTIES = List.of(
+		new ProviderConfigProperty("length", "Code length", "The number of digits of the generated code.", ProviderConfigProperty.STRING_TYPE, 6),
+		new ProviderConfigProperty("ttl", "Time-to-live", "The time to live in seconds for the code to be valid.", ProviderConfigProperty.STRING_TYPE, "300"),
+		new ProviderConfigProperty("senderId", "SenderId", "The sender ID is displayed as the message sender on the receiving device.", ProviderConfigProperty.STRING_TYPE, "Keycloak"),
+		new ProviderConfigProperty("simulation", "Simulation mode", "In simulation mode, the SMS won't be sent, but printed to the server logs", ProviderConfigProperty.BOOLEAN_TYPE, true),
+		new ProviderConfigProperty("countrycode", "Default country prefix", "Default country prefix that is assumed if user does not provide one.", ProviderConfigProperty.STRING_TYPE, "+49"),
+		new ProviderConfigProperty("apiurl", "SMS API URL", "The path to the API that receives an HTTP request.", ProviderConfigProperty.STRING_TYPE, "https://example.com/api/sms/send"),
+		new ProviderConfigProperty("getUrl", "SMS API GET URL template", "If your SMS API expects a GET request instead of POST, you can set here a URL template with placeholders: {phone}, {message}, {apitoken}, {senderId}. If empty, a POST request will be sent.", ProviderConfigProperty.STRING_TYPE, ""),
+		new ProviderConfigProperty("stripPlusPrefix", "Strip + from phone number", "Remove the leading + from phone numbers before sending. Required for APIs expecting E.164 without + prefix (e.g., BudgetSMS).", ProviderConfigProperty.BOOLEAN_TYPE, false),
+		new ProviderConfigProperty("urlencode", "URL encode data", "By default send a JSON in HTTP POST body. You can URL encode the data instead.", ProviderConfigProperty.BOOLEAN_TYPE, false),
+		new ProviderConfigProperty("apiTokenInHeader", "Put API Secret Token in Authorization Header", "If set, API Secret will be sent as Authorization Header, 'API Secret Token Attribute' and 'Basic Auth Username' will be ignored.", ProviderConfigProperty.BOOLEAN_TYPE, false),
+		new ProviderConfigProperty("apitokenattribute", "API Secret Token Attribute (optional)", "Name of attribute that contains your API token/secret. In some APIs the secret is already configured in the path. In this case, this can be left empty.", ProviderConfigProperty.STRING_TYPE, ""),
+		new ProviderConfigProperty("apitoken", "API Secret (optional)", "Your API secret. If a Basic Auth user is set, this will be the Basic Auth password.", ProviderConfigProperty.STRING_TYPE, "changeme"),
+		new ProviderConfigProperty("apiuser", "Basic Auth Username (optional)", "If set, Basic Auth will be performed. Leave empty if not required.", ProviderConfigProperty.STRING_TYPE, ""),
+		new ProviderConfigProperty("messageattribute", "Message Attribute", "The attribute that contains the SMS message text.", ProviderConfigProperty.STRING_TYPE, "text"),
+		new ProviderConfigProperty("receiverattribute", "Receiver Phone Number Attribute", "The attribute that contains the receiver phone number.", ProviderConfigProperty.STRING_TYPE, "to"),
+		new ProviderConfigProperty("receiverJsonTemplate", "Receiver Phone Number Json value template", "Receiver value structure can be customised to match API requirements.", ProviderConfigProperty.STRING_TYPE, "\"%s\""),
+		new ProviderConfigProperty("senderattribute", "Sender Phone Number Attribute", "The attribute that contains the sender phone number. Leave empty if not required.", ProviderConfigProperty.STRING_TYPE, "from"),
+		new ProviderConfigProperty("useUuid", "Use message UUID", "If set, data will contain UUID.", ProviderConfigProperty.BOOLEAN_TYPE, false),
+		new ProviderConfigProperty("uuidAttribute", "UUID attribute", "The attribute that contains the UUID. Applicable only when 'Use message UUID' is set.", ProviderConfigProperty.STRING_TYPE, ""),
+		new ProviderConfigProperty("jsonTemplate", "Request JSON template", "Custom JSON Body template with \"%s\" placeholders for UUID (if 'Use message UUID' is set), phone number and message (in that order). If empty, default template will be used.", ProviderConfigProperty.TEXT_TYPE, ""),
+		new ProviderConfigProperty("forceSecondFactor", "Force 2FA", "If 2FA authentication is not configured, the user is forced to setup SMS Authentication.", ProviderConfigProperty.BOOLEAN_TYPE, false),
+		new ProviderConfigProperty("whitelist", "Excluded from enforced 2FA", "All users with the here selected role are not forced to setup 2FA.", ProviderConfigProperty.ROLE_TYPE, null),
+		new ProviderConfigProperty("enableByDefault", "Enable 2FA by default", "If enabled, users who have the configured mobile number attribute will have SMS 2FA activated automatically without any manual setup required.", ProviderConfigProperty.BOOLEAN_TYPE, false),
+		new ProviderConfigProperty("mobileNumberAttribute", "Mobile number user attribute", "Name of the user attribute containing the mobile phone number used for auto-enrollment when 'Enable 2FA by default' is active.", ProviderConfigProperty.STRING_TYPE, "mobile_number"),
+		new ProviderConfigProperty("hideResponsePayload", "Redacted API response log message", "Don't log API response body of SMS send request.", ProviderConfigProperty.BOOLEAN_TYPE, false),
+		new ProviderConfigProperty("mobileInputFieldPlaceholder", "Phone number input field placeholder", "The placeholder string user in the phone number input field", ProviderConfigProperty.STRING_TYPE, ""),
+		new ProviderConfigProperty("storeInAttribute", "Set phone number as attribute", "Sets the phone number as a user attribute.", ProviderConfigProperty.BOOLEAN_TYPE, false),
+		new ProviderConfigProperty("normalizePhoneNumber", "Format phone number", "Normalize the phone number using the E164 standard.", ProviderConfigProperty.BOOLEAN_TYPE, false),
+		new ProviderConfigProperty("numberTypeFilters", "Valid number type filters", "A list of valid number types to filter the input phone number by. Possible values are: FIXED_LINE, MOBILE, "
+			+ " FIXED_LINE_OR_MOBILE, PAGER, TOLL_FREE, PREMIUM_RATE, SHARED_COST, PERSONAL_NUMBER, VOIP, UAN, VOICEMAIL.", ProviderConfigProperty.MULTIVALUED_STRING_TYPE, Collections.emptyList()),
+		new ProviderConfigProperty("forceRetryOnBadFormat", "Ask for new number if checks fail", "Sets an error message and asks the user to re-enter phone number if formatting checks are not successfully passed.", ProviderConfigProperty.BOOLEAN_TYPE, false),
+		new ProviderConfigProperty("enforcePhoneNumberUniqueness", "Enforce phone number uniqueness", "If enabled, prevents users from registering a phone number that is already in use by another user.", ProviderConfigProperty.BOOLEAN_TYPE, true),
+		new ProviderConfigProperty("countryCodeList", "List of country code", "Sets the list of country code in a select input to display to the user the supported countries. List separated by commas (ex : FR,DE,GB)", ProviderConfigProperty.STRING_TYPE, "")
+	);
+
+	/**
+	 * Authenticator execution config properties. Today the full list is also the RA base
+	 * (see {@link #getSmsRequiredActionConfigProperties()}) so both UIs stay aligned with
+	 * legacy alias {@code sms-2fa}. Prefer splitting later: execution = login overrides /
+	 * gateway; RA = realm-global SMS + enrollment. Sequence: deprecate this monolithic
+	 * shared surface (and legacy alias reliance), then drop enrollment-only keys from the
+	 * authenticator UI (and/or trim the RA) in a later release with an explicit breaking-change warning.
+	 */
+	public static List<ProviderConfigProperty> getSmsAuthenticatorConfigProperties() {
+		return SMS_AUTHENTICATOR_CONFIG_PROPERTIES;
+	}
+
+	/**
+	 * Required-action admin metadata: same keys as the authenticator for legacy
+	 * {@code sms-2fa} compatibility; only {@code simulation} defaults to {@code false}
+	 * (authenticator keeps {@code true}) so opening the gear does not silently opt into
+	 * inline simulation. Intended later split: RA = realm-global SMS + enrollment policy;
+	 * authenticator = login overrides / gateway. Deprecate the shared surface first, then
+	 * trim in a later release with a breaking-change warning.
+	 */
+	public static List<ProviderConfigProperty> getSmsRequiredActionConfigProperties() {
+		return SMS_REQUIRED_ACTION_CONFIG_PROPERTIES;
+	}
+
+	private static final List<ProviderConfigProperty> SMS_REQUIRED_ACTION_CONFIG_PROPERTIES =
+		withSimulationDefault(SMS_AUTHENTICATOR_CONFIG_PROPERTIES, false);
+
+	private static List<ProviderConfigProperty> withSimulationDefault(
+		List<ProviderConfigProperty> source,
+		boolean simulationDefault
+	) {
+		List<ProviderConfigProperty> out = new ArrayList<>(source.size());
+		for (ProviderConfigProperty p : source) {
+			if ("simulation".equals(p.getName())) {
+				out.add(new ProviderConfigProperty(
+					p.getName(),
+					p.getLabel(),
+					p.getHelpText(),
+					p.getType(),
+					simulationDefault
+				));
+			} else {
+				out.add(p);
+			}
+		}
+		return List.copyOf(out);
+	}
 
 
 	@Override
@@ -71,41 +157,7 @@ public class SmsAuthenticatorFactory implements AuthenticatorFactory {
 
 	@Override
 	public List<ProviderConfigProperty> getConfigProperties() {
-		return List.of(
-			new ProviderConfigProperty("length", "Code length", "The number of digits of the generated code.", ProviderConfigProperty.STRING_TYPE, 6),
-			new ProviderConfigProperty("ttl", "Time-to-live", "The time to live in seconds for the code to be valid.", ProviderConfigProperty.STRING_TYPE, "300"),
-			new ProviderConfigProperty("senderId", "SenderId", "The sender ID is displayed as the message sender on the receiving device.", ProviderConfigProperty.STRING_TYPE, "Keycloak"),
-			new ProviderConfigProperty("simulation", "Simulation mode", "In simulation mode, the SMS won't be sent, but printed to the server logs", ProviderConfigProperty.BOOLEAN_TYPE, true),
-			new ProviderConfigProperty("countrycode", "Default country prefix", "Default country prefix that is assumed if user does not provide one.", ProviderConfigProperty.STRING_TYPE, "+49"),
-			new ProviderConfigProperty("apiurl", "SMS API URL", "The path to the API that receives an HTTP request.", ProviderConfigProperty.STRING_TYPE, "https://example.com/api/sms/send"),
-			new ProviderConfigProperty("getUrl", "SMS API GET URL template", "If your SMS API expects a GET request instead of POST, you can set here a URL template with placeholders: {phone}, {message}, {apitoken}, {senderId}. If empty, a POST request will be sent.", ProviderConfigProperty.STRING_TYPE, ""),
-			new ProviderConfigProperty("stripPlusPrefix", "Strip + from phone number", "Remove the leading + from phone numbers before sending. Required for APIs expecting E.164 without + prefix (e.g., BudgetSMS).", ProviderConfigProperty.BOOLEAN_TYPE, false),
-			new ProviderConfigProperty("urlencode", "URL encode data", "By default send a JSON in HTTP POST body. You can URL encode the data instead.", ProviderConfigProperty.BOOLEAN_TYPE, false),
-			new ProviderConfigProperty("apiTokenInHeader", "Put API Secret Token in Authorization Header", "If set, API Secret will be sent as Authorization Header, 'API Secret Token Attribute' and 'Basic Auth Username' will be ignored.", ProviderConfigProperty.BOOLEAN_TYPE, false),
-			new ProviderConfigProperty("apitokenattribute", "API Secret Token Attribute (optional)", "Name of attribute that contains your API token/secret. In some APIs the secret is already configured in the path. In this case, this can be left empty.", ProviderConfigProperty.STRING_TYPE, ""),
-			new ProviderConfigProperty("apitoken", "API Secret (optional)", "Your API secret. If a Basic Auth user is set, this will be the Basic Auth password.", ProviderConfigProperty.STRING_TYPE, "changeme"),
-			new ProviderConfigProperty("apiuser", "Basic Auth Username (optional)", "If set, Basic Auth will be performed. Leave empty if not required.", ProviderConfigProperty.STRING_TYPE, ""),
-			new ProviderConfigProperty("messageattribute", "Message Attribute", "The attribute that contains the SMS message text.", ProviderConfigProperty.STRING_TYPE, "text"),
-			new ProviderConfigProperty("receiverattribute", "Receiver Phone Number Attribute", "The attribute that contains the receiver phone number.", ProviderConfigProperty.STRING_TYPE, "to"),
-			new ProviderConfigProperty("receiverJsonTemplate", "Receiver Phone Number Json value template", "Receiver value structure can be customised to match API requirements.", ProviderConfigProperty.STRING_TYPE, "\"%s\""),
-			new ProviderConfigProperty("senderattribute", "Sender Phone Number Attribute", "The attribute that contains the sender phone number. Leave empty if not required.", ProviderConfigProperty.STRING_TYPE, "from"),
-			new ProviderConfigProperty("useUuid", "Use message UUID", "If set, data will contain UUID.", ProviderConfigProperty.BOOLEAN_TYPE, false),
-			new ProviderConfigProperty("uuidAttribute", "UUID attribute", "The attribute that contains the UUID. Applicable only when 'Use message UUID' is set.", ProviderConfigProperty.STRING_TYPE, ""),
-			new ProviderConfigProperty("jsonTemplate", "Request JSON template", "Custom JSON Body template with \"%s\" placeholders for UUID (if 'Use message UUID' is set), phone number and message (in that order). If empty, default template will be used.", ProviderConfigProperty.TEXT_TYPE, ""),
-			new ProviderConfigProperty("forceSecondFactor", "Force 2FA", "If 2FA authentication is not configured, the user is forced to setup SMS Authentication.", ProviderConfigProperty.BOOLEAN_TYPE, false),
-			new ProviderConfigProperty("whitelist", "Excluded from enforced 2FA", "All users with the here selected role are not forced to setup 2FA.", ProviderConfigProperty.ROLE_TYPE, null),
-			new ProviderConfigProperty("enableByDefault", "Enable 2FA by default", "If enabled, users who have the configured mobile number attribute will have SMS 2FA activated automatically without any manual setup required.", ProviderConfigProperty.BOOLEAN_TYPE, false),
-			new ProviderConfigProperty("mobileNumberAttribute", "Mobile number user attribute", "Name of the user attribute containing the mobile phone number used for auto-enrollment when 'Enable 2FA by default' is active.", ProviderConfigProperty.STRING_TYPE, "mobile_number"),
-			new ProviderConfigProperty("hideResponsePayload", "Redacted API response log message", "Don't log API response body of SMS send request.", ProviderConfigProperty.BOOLEAN_TYPE, false),
-			new ProviderConfigProperty("mobileInputFieldPlaceholder", "Phone number input field placeholder", "The placeholder string user in the phone number input field", ProviderConfigProperty.STRING_TYPE, ""),
-			new ProviderConfigProperty("storeInAttribute", "Set phone number as attribute", "Sets the phone number as a user attribute.", ProviderConfigProperty.BOOLEAN_TYPE, false),
-			new ProviderConfigProperty("normalizePhoneNumber", "Format phone number", "Normalize the phone number using the E164 standard.", ProviderConfigProperty.BOOLEAN_TYPE, false),
-			new ProviderConfigProperty("numberTypeFilters", "Valid number type filters", "A list of valid number types to filter the input phone number by. Possible values are: FIXED_LINE, MOBILE, "
-				+ " FIXED_LINE_OR_MOBILE, PAGER, TOLL_FREE, PREMIUM_RATE, SHARED_COST, PERSONAL_NUMBER, VOIP, UAN, VOICEMAIL.", ProviderConfigProperty.MULTIVALUED_STRING_TYPE, Collections.emptyList()),
-			new ProviderConfigProperty("forceRetryOnBadFormat", "Ask for new number if checks fail", "Sets an error message and asks the user to re-enter phone number if formatting checks are not successfully passed.", ProviderConfigProperty.BOOLEAN_TYPE, false),
-			new ProviderConfigProperty("enforcePhoneNumberUniqueness", "Enforce phone number uniqueness", "If enabled, prevents users from registering a phone number that is already in use by another user.", ProviderConfigProperty.BOOLEAN_TYPE, true),
-			new ProviderConfigProperty("countryCodeList", "List of country code", "Sets the list of country code in a select input to display to the user the supported countries. List separated by commas (ex : FR,DE,GB)", ProviderConfigProperty.STRING_TYPE, "")
-		);
+		return getSmsAuthenticatorConfigProperties();
 	}
 
 	@Override

--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsRegistrationConfigResolver.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsRegistrationConfigResolver.java
@@ -1,0 +1,176 @@
+package netzbegruenung.keycloak.authenticator;
+
+import org.jboss.logging.Logger;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RequiredActionProviderModel;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Resolves SMS settings for required actions (mobile number capture and validation). Those run outside
+ * an authentication execution, so they cannot use {@code AuthenticationFlowContext#getAuthenticatorConfig()}.
+ * <p>
+ * <strong>Inline mode (new)</strong>: set SMS fields on the &quot;Update Mobile Number&quot; required action
+ * (Authentication → Required actions → settings). When {@link #isInlineSmsRegistration(Map)} is true ({@code apiurl}
+ * or {@code simulation=true}), registration uses only that map (defaults fill other keys). Legacy alias config is
+ * not merged in. Partial edits (e.g. code length only) keep using the legacy alias.
+ * <p>
+ * <strong>Legacy fallback</strong>: otherwise load the realm {@linkplain AuthenticatorConfigModel authenticator config}
+ * with alias {@value #LEGACY_DEFAULT_ALIAS} (historical default used when creating the SMS step in a flow).
+ */
+public final class SmsRegistrationConfigResolver {
+
+	private static final Logger logger = Logger.getLogger(SmsRegistrationConfigResolver.class);
+
+	public static final String LEGACY_DEFAULT_ALIAS = "sms-2fa";
+
+	/** Factory defaults for OTP length and TTL when absent from the resolved config. */
+	public static final String DEFAULT_LENGTH = "6";
+	public static final String DEFAULT_TTL_SECONDS = "300";
+
+	private SmsRegistrationConfigResolver() {}
+
+	/**
+	 * {@code true} when the required-action map is a complete enough Option A setup to run registration
+	 * without the legacy flow alias {@value #LEGACY_DEFAULT_ALIAS}. Requires {@code apiurl} or explicit
+	 * {@code simulation=true}; {@code length} / {@code ttl} alone do not enable inline mode (legacy config
+	 * is still used for those partial edits).
+	 */
+	public static boolean isInlineSmsRegistration(Map<String, String> ra) {
+		if (ra == null || ra.isEmpty()) {
+			return false;
+		}
+		if (hasNonBlank(ra, "apiurl")) {
+			return true;
+		}
+		return Boolean.parseBoolean(ra.get("simulation"));
+	}
+
+	private static boolean hasNonBlank(Map<String, String> m, String k) {
+		String v = m.get(k);
+		return v != null && !v.isBlank();
+	}
+
+	/** Raw config from the &quot;Update Mobile Number&quot; required action (empty map if none). */
+	public static Map<String, String> readPhoneNumberRequiredActionConfig(RealmModel realm) {
+		Map<String, String> cfg = realm.getRequiredActionProvidersStream()
+			.filter(p -> PhoneNumberRequiredAction.PROVIDER_ID.equals(p.getProviderId()))
+			.findFirst()
+			.map(RequiredActionProviderModel::getConfig)
+			.orElse(null);
+		if (cfg == null || cfg.isEmpty()) {
+			return Map.of();
+		}
+		return new HashMap<>(cfg);
+	}
+
+	public static Map<String, String> getMergedRegistrationConfig(RealmModel realm) {
+		Map<String, String> ra = readPhoneNumberRequiredActionConfig(realm);
+		Map<String, String> merged = new HashMap<>();
+		if (isInlineSmsRegistration(ra)) {
+			merged.putAll(buildInlineRegistrationConfig(ra));
+		} else {
+			AuthenticatorConfigModel acm = realm.getAuthenticatorConfigByAlias(LEGACY_DEFAULT_ALIAS);
+			if (acm != null && acm.getConfig() != null) {
+				merged.putAll(acm.getConfig());
+			}
+		}
+		ensureOtpLengthAndTtlDefaults(merged);
+		return Collections.unmodifiableMap(merged);
+	}
+
+	/** Legacy configs may omit keys present in the admin UI by default; align with {@link SmsAuthenticatorFactory} defaults. */
+	private static void ensureOtpLengthAndTtlDefaults(Map<String, String> merged) {
+		if (merged.isEmpty()) {
+			return;
+		}
+		String length = merged.get("length");
+		if (length == null || length.isBlank()) {
+			merged.put("length", DEFAULT_LENGTH);
+		}
+		String ttl = merged.get("ttl");
+		if (ttl == null || ttl.isBlank()) {
+			merged.put("ttl", DEFAULT_TTL_SECONDS);
+		}
+	}
+
+	/**
+	 * Logs a WARN when the realm still relies on the flow-bound authenticator config {@value #LEGACY_DEFAULT_ALIAS}
+	 * for SMS base settings instead of inline fields on the &quot;Update Mobile Number&quot; required action.
+	 * Intended to be invoked before each outbound SMS so operators notice legacy setups.
+	 */
+	public static void logWarningIfUsingLegacySmsAuthenticatorConfig(RealmModel realm) {
+		if (isInlineSmsRegistration(readPhoneNumberRequiredActionConfig(realm))) {
+			return;
+		}
+		AuthenticatorConfigModel legacy = realm.getAuthenticatorConfigByAlias(LEGACY_DEFAULT_ALIAS);
+		if (legacy == null || legacy.getConfig() == null || legacy.getConfig().isEmpty()) {
+			return;
+		}
+		logger.warnf(
+			"SMS authenticator plugin: realm \"%s\" still uses legacy authenticator config alias \"%s\" for SMS settings. "
+				+ "Migrate to inline settings on required action \"Update Mobile Number\" (Authentication → Required actions → gear icon) to avoid depending on a flow alias.",
+			realm.getName(),
+			LEGACY_DEFAULT_ALIAS
+		);
+	}
+
+	/**
+	 * Effective SMS key/value map for a browser-flow (or other) execution: starts from the same source as
+	 * registration ({@link #getMergedRegistrationConfig(RealmModel)}), then applies the execution-bound
+	 * authenticator config on top when present (only non-blank execution values override the base).
+	 */
+	public static Map<String, String> getEffectiveSmsConfigForExecution(RealmModel realm, AuthenticatorConfigModel executionConfig) {
+		Map<String, String> eff = new HashMap<>(getMergedRegistrationConfig(realm));
+		if (executionConfig != null && executionConfig.getConfig() != null) {
+			executionConfig.getConfig().forEach((k, v) -> {
+				if (v != null && !v.isBlank()) {
+					eff.put(k, v);
+				}
+			});
+		}
+		return Collections.unmodifiableMap(eff);
+	}
+
+	/**
+	 * Applies required-action defaults from {@link SmsAuthenticatorFactory#getSmsRequiredActionConfigProperties()}
+	 * to a required-action map (same as at runtime for inline mode; simulation defaults to false).
+	 * Used by admin validation so checks match registration behavior.
+	 */
+	public static Map<String, String> materializeInlineRegistrationConfig(Map<String, String> ra) {
+		return buildInlineRegistrationConfig(ra);
+	}
+
+	private static Map<String, String> buildInlineRegistrationConfig(Map<String, String> ra) {
+		Map<String, String> out = new HashMap<>();
+		for (ProviderConfigProperty p : SmsAuthenticatorFactory.getSmsRequiredActionConfigProperties()) {
+			String k = p.getName();
+			if (p.getType() == ProviderConfigProperty.ROLE_TYPE) {
+				String v = ra.get(k);
+				if (v != null && !v.isBlank()) {
+					out.put(k, v);
+				}
+				continue;
+			}
+			String v = ra.get(k);
+			if (v != null && !v.isBlank()) {
+				out.put(k, v);
+			} else if ("apiurl".equals(k) && v != null && v.isEmpty()) {
+				out.put(k, "");
+			} else {
+				Object d = p.getDefaultValue();
+				if (d == null || d instanceof List) {
+					out.put(k, "");
+				} else {
+					out.put(k, String.valueOf(d));
+				}
+			}
+		}
+		return out;
+	}
+}

--- a/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/PhoneNumberRequiredActionFactoryTest.java
+++ b/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/PhoneNumberRequiredActionFactoryTest.java
@@ -1,0 +1,111 @@
+package netzbegruenung.keycloak.authenticator;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.keycloak.component.ComponentValidationException;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RequiredActionConfigModel;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+class PhoneNumberRequiredActionFactoryTest {
+
+	private final PhoneNumberRequiredActionFactory factory = new PhoneNumberRequiredActionFactory();
+
+	private static RequiredActionConfigModel config(Map<String, String> cfg) {
+		RequiredActionConfigModel model = mock(RequiredActionConfigModel.class);
+		org.mockito.Mockito.when(model.getConfig()).thenReturn(cfg);
+		return model;
+	}
+
+
+	@Test
+	void configMetadataSimulationDefaultsToFalse() {
+		ProviderConfigProperty simulation = factory.getConfigMetadata().stream()
+			.filter(p -> "simulation".equals(p.getName()))
+			.findFirst()
+			.orElse(null);
+		assertNotNull(simulation);
+		assertEquals(Boolean.FALSE, simulation.getDefaultValue());
+	}
+
+	@Nested
+	class ValidateConfig {
+
+		@Test
+		void inlineApiUrlOnlyAcceptsFactorySimulationDefault() {
+			RequiredActionConfigModel model = config(Map.of("apiurl", "https://sms.example/send"));
+
+			assertDoesNotThrow(() -> factory.validateConfig(mock(KeycloakSession.class), mock(RealmModel.class), model));
+		}
+
+		@Test
+		void inlineSimulationTrueWithoutApiUrlAccepted() {
+			RequiredActionConfigModel model = config(Map.of("simulation", "true"));
+
+			assertDoesNotThrow(() -> factory.validateConfig(mock(KeycloakSession.class), mock(RealmModel.class), model));
+		}
+
+		@Test
+		void simulationFalseAloneSkipsInlineValidation() {
+			RequiredActionConfigModel model = config(Map.of("simulation", "false"));
+
+			assertDoesNotThrow(() -> factory.validateConfig(mock(KeycloakSession.class), mock(RealmModel.class), model));
+		}
+
+		@Test
+		void partialConfigSkipsValidation() {
+			RequiredActionConfigModel model = config(Map.of("length", "8"));
+
+			assertDoesNotThrow(() -> factory.validateConfig(mock(KeycloakSession.class), mock(RealmModel.class), model));
+		}
+
+		@Test
+		void inlineWithNonIntegerLengthThrows() {
+			RequiredActionConfigModel model = config(Map.of(
+				"apiurl", "https://sms.example/send",
+				"length", "abc"
+			));
+
+			assertThrows(
+				ComponentValidationException.class,
+				() -> factory.validateConfig(mock(KeycloakSession.class), mock(RealmModel.class), model)
+			);
+		}
+
+		@Test
+		void inlineWithSimulationFalseAndBlankApiUrlThrows() {
+			RequiredActionConfigModel model = config(Map.of(
+				"apiurl", "",
+				"simulation", "false"
+			));
+
+			assertThrows(
+				ComponentValidationException.class,
+				() -> factory.validateConfig(mock(KeycloakSession.class), mock(RealmModel.class), model)
+			);
+		}
+
+		@Test
+		void inlineWithNonIntegerTtlThrows() {
+			RequiredActionConfigModel model = config(Map.of(
+				"apiurl", "https://sms.example/send",
+				"ttl", "xyz"
+			));
+
+			assertThrows(
+				ComponentValidationException.class,
+				() -> factory.validateConfig(mock(KeycloakSession.class), mock(RealmModel.class), model)
+			);
+		}
+	}
+}

--- a/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/SmsRegistrationConfigResolverTest.java
+++ b/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/SmsRegistrationConfigResolverTest.java
@@ -1,0 +1,247 @@
+package netzbegruenung.keycloak.authenticator;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RequiredActionProviderModel;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SmsRegistrationConfigResolverTest {
+
+	private static RealmModel stubRealm(
+		Map<String, String> requiredActionConfig,
+		Map<String, String> legacyAuthenticatorConfig
+	) {
+		RealmModel realm = mock(RealmModel.class);
+		if (requiredActionConfig != null) {
+			RequiredActionProviderModel ra = mock(RequiredActionProviderModel.class);
+			when(ra.getProviderId()).thenReturn(PhoneNumberRequiredAction.PROVIDER_ID);
+			when(ra.getConfig()).thenReturn(requiredActionConfig);
+			when(realm.getRequiredActionProvidersStream()).thenAnswer(inv -> Stream.of(ra));
+		} else {
+			when(realm.getRequiredActionProvidersStream()).thenAnswer(inv -> Stream.empty());
+		}
+		if (legacyAuthenticatorConfig != null) {
+			AuthenticatorConfigModel legacy = mock(AuthenticatorConfigModel.class);
+			when(legacy.getConfig()).thenReturn(legacyAuthenticatorConfig);
+			when(realm.getAuthenticatorConfigByAlias(SmsRegistrationConfigResolver.LEGACY_DEFAULT_ALIAS))
+				.thenReturn(legacy);
+		} else {
+			when(realm.getAuthenticatorConfigByAlias(SmsRegistrationConfigResolver.LEGACY_DEFAULT_ALIAS))
+				.thenReturn(null);
+		}
+		return realm;
+	}
+
+	@Nested
+	class IsInlineSmsRegistration {
+
+		@Test
+		void simulationTrueEnablesInline() {
+			assertTrue(SmsRegistrationConfigResolver.isInlineSmsRegistration(Map.of("simulation", "true")));
+		}
+
+		@Test
+		void simulationFalseAloneDoesNotEnableInline() {
+			assertFalse(SmsRegistrationConfigResolver.isInlineSmsRegistration(Map.of("simulation", "false")));
+		}
+
+		@Test
+		void blankApiUrlDoesNotEnableInline() {
+			assertFalse(SmsRegistrationConfigResolver.isInlineSmsRegistration(Map.of("apiurl", "   ")));
+			assertFalse(SmsRegistrationConfigResolver.isInlineSmsRegistration(Map.of("apiurl", "")));
+		}
+
+	}
+
+	@Nested
+	class GetMergedRegistrationConfig {
+
+		@Test
+		void legacyAliasAlone() {
+			RealmModel realm = stubRealm(null, Map.of(
+				"apiurl", "https://legacy.example/send",
+				"apitoken", "legacy-secret",
+				"length", "6",
+				"ttl", "300"
+			));
+
+			Map<String, String> merged = SmsRegistrationConfigResolver.getMergedRegistrationConfig(realm);
+
+			assertEquals("https://legacy.example/send", merged.get("apiurl"));
+			assertEquals("legacy-secret", merged.get("apitoken"));
+			assertEquals("6", merged.get("length"));
+			assertEquals("300", merged.get("ttl"));
+		}
+
+		@Test
+		void legacyWithoutLengthOrTtlGetsDefaults() {
+			RealmModel realm = stubRealm(null, Map.of(
+				"apiurl", "https://legacy.example/send"
+			));
+
+			Map<String, String> merged = SmsRegistrationConfigResolver.getMergedRegistrationConfig(realm);
+
+			assertEquals(SmsRegistrationConfigResolver.DEFAULT_LENGTH, merged.get("length"));
+			assertEquals(SmsRegistrationConfigResolver.DEFAULT_TTL_SECONDS, merged.get("ttl"));
+		}
+
+		@Test
+		void inlineCompleteIgnoresLegacy() {
+			Map<String, String> ra = Map.of(
+				"apiurl", "https://inline.example/send",
+				"apitoken", "inline-secret",
+				"length", "8",
+				"ttl", "120",
+				"simulation", "false"
+			);
+			Map<String, String> legacy = Map.of(
+				"apiurl", "https://legacy.example/send",
+				"length", "6"
+			);
+			RealmModel realm = stubRealm(ra, legacy);
+
+			Map<String, String> merged = SmsRegistrationConfigResolver.getMergedRegistrationConfig(realm);
+
+			assertEquals("https://inline.example/send", merged.get("apiurl"));
+			assertEquals("inline-secret", merged.get("apitoken"));
+			assertEquals("8", merged.get("length"));
+			assertEquals("120", merged.get("ttl"));
+		}
+
+		@Test
+		void inlineWithApiUrlOnlyFillsRequiredActionDefaults() {
+			RealmModel realm = stubRealm(Map.of(
+				"apiurl", "https://inline.example/send"
+			), Map.of("apiurl", "https://legacy.example/send"));
+
+			Map<String, String> merged = SmsRegistrationConfigResolver.getMergedRegistrationConfig(realm);
+
+			assertEquals("https://inline.example/send", merged.get("apiurl"));
+			assertEquals("6", merged.get("length"));
+			assertEquals("300", merged.get("ttl"));
+			assertEquals("false", merged.get("simulation"));
+		}
+
+		@Test
+		void partialRequiredActionUsesLegacyNotInline() {
+			RealmModel realm = stubRealm(Map.of("length", "8"), Map.of(
+				"apiurl", "https://legacy.example/send",
+				"length", "6",
+				"ttl", "300"
+			));
+
+			Map<String, String> merged = SmsRegistrationConfigResolver.getMergedRegistrationConfig(realm);
+
+			assertEquals("https://legacy.example/send", merged.get("apiurl"));
+			assertEquals("6", merged.get("length"));
+		}
+
+		@Test
+		void emptyWhenNoLegacyAndNoInline() {
+			RealmModel realm = stubRealm(null, null);
+
+			assertTrue(SmsRegistrationConfigResolver.getMergedRegistrationConfig(realm).isEmpty());
+		}
+	}
+
+	@Nested
+	class GetEffectiveSmsConfigForExecution {
+
+		@Test
+		void executionConfigOverridesMergedBase() {
+			RealmModel realm = stubRealm(null, Map.of(
+				"apiurl", "https://legacy.example/send",
+				"length", "6",
+				"ttl", "300"
+			));
+
+			AuthenticatorConfigModel execution = mock(AuthenticatorConfigModel.class);
+			when(execution.getConfig()).thenReturn(Map.of("length", "4", "ttl", "120"));
+
+			Map<String, String> eff = SmsRegistrationConfigResolver.getEffectiveSmsConfigForExecution(realm, execution);
+
+			assertEquals("4", eff.get("length"));
+			assertEquals("120", eff.get("ttl"));
+			assertEquals("https://legacy.example/send", eff.get("apiurl"));
+		}
+
+		@Test
+		void inlineBaseWithExecutionOverride() {
+			RealmModel realm = stubRealm(Map.of(
+				"apiurl", "https://inline.example/send",
+				"length", "8",
+				"ttl", "120"
+			), Map.of("apiurl", "https://legacy.example/send", "length", "6"));
+
+			AuthenticatorConfigModel execution = mock(AuthenticatorConfigModel.class);
+			when(execution.getConfig()).thenReturn(Map.of("ttl", "60"));
+
+			Map<String, String> eff = SmsRegistrationConfigResolver.getEffectiveSmsConfigForExecution(realm, execution);
+
+			assertEquals("https://inline.example/send", eff.get("apiurl"));
+			assertEquals("8", eff.get("length"));
+			assertEquals("60", eff.get("ttl"));
+		}
+
+		@Test
+		void nullExecutionMatchesMergedRegistration() {
+			RealmModel realm = stubRealm(null, Map.of(
+				"apiurl", "https://legacy.example/send",
+				"length", "6",
+				"ttl", "300"
+			));
+
+			Map<String, String> merged = SmsRegistrationConfigResolver.getMergedRegistrationConfig(realm);
+			Map<String, String> eff = SmsRegistrationConfigResolver.getEffectiveSmsConfigForExecution(realm, null);
+
+			assertEquals(merged, eff);
+		}
+
+		@Test
+		void blankExecutionValueDoesNotOverwriteBase() {
+			RealmModel realm = stubRealm(null, Map.of(
+				"apiurl", "https://legacy.example/send",
+				"mobileInputFieldPlaceholder", "legacy-placeholder",
+				"length", "6",
+				"ttl", "300"
+			));
+
+			Map<String, String> executionCfg = new HashMap<>();
+			executionCfg.put("mobileInputFieldPlaceholder", "");
+			executionCfg.put("length", "   ");
+			AuthenticatorConfigModel execution = mock(AuthenticatorConfigModel.class);
+			when(execution.getConfig()).thenReturn(executionCfg);
+
+			Map<String, String> eff = SmsRegistrationConfigResolver.getEffectiveSmsConfigForExecution(realm, execution);
+
+			assertEquals("legacy-placeholder", eff.get("mobileInputFieldPlaceholder"));
+			assertEquals("6", eff.get("length"));
+		}
+	}
+
+	@Nested
+	class MaterializeInlineRegistrationConfig {
+
+		@Test
+		void omitsBlankWhitelist() {
+			Map<String, String> materialized = SmsRegistrationConfigResolver.materializeInlineRegistrationConfig(
+				Map.of("apiurl", "https://inline.example/send")
+			);
+
+			assertNull(materialized.get("whitelist"));
+		}
+
+	}
+}


### PR DESCRIPTION
Hello,

Addresses the original problem where phone registration required actions only read SMS settings from a hard-coded authenticator alias (sms-2fa), which was fragile and unclear for operators. (#201)

**Changes**

- Registration SMS settings can live on the “Update Mobile Number” required action (gear icon), using the same fields as the SMS authenticator, so registration no longer depends on that alias when this path is used.
<img width="2981" height="1266" alt="image" src="https://github.com/user-attachments/assets/ed5aef23-8ad0-47f4-a99a-645c0928521c" />

- Legacy behaviour is preserved: if those fields are left empty, the plugin still loads the realm authenticator config with alias sms-2fa (same as before for upgrades).
- Server log: a WARN is emitted before each outbound SMS when the realm still relies on the legacy sms-2fa config instead of inline required-action settings (to encourage migration).
`WARN  [netzbegruenung.keycloak.authenticator.SmsRegistrationConfigResolver] (executor │-thread-10) SMS authenticator plugin: realm "master" still uses legacy authenticator config alias "sms-2fa" for SMS settings. Migrate to inline settings on required action "Update Mobile Number" (Authentication → Required actions → gear icon) to avoid depending on a flow alias.`
- README updated to describe where configuration lives (login vs registration) and the two registration options.

closes #201 