### PR TITLE
feat(sms-authenticator): pass phone number to login-sms template

### DIFF
--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticator.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticator.java
@@ -89,7 +89,10 @@ public class SmsAuthenticator implements Authenticator, CredentialValidator<SmsA
 
 			SmsServiceFactory.get(config.getConfig()).send(mobileNumber, smsText);
 
-			context.challenge(context.form().setAttribute("realm", realm).createForm(TPL_CODE));
+			context.challenge(context.form()
+				.setAttribute("realm", realm)
+				.setAttribute("phoneNumber", mobileNumber)
+				.createForm(TPL_CODE));
 		} catch (Exception e) {
 			context.failureChallenge(AuthenticationFlowError.INTERNAL_ERROR,
 				context.form().setError("smsAuthSmsNotSent", "Error. Use another method.")
@@ -123,8 +126,10 @@ public class SmsAuthenticator implements Authenticator, CredentialValidator<SmsA
 			}
 		} else {
 			// invalid
+			String mobileNumber = getMobileNumber(context);
 			context.getEvent().user(context.getUser()).error("invalid_user_credentials");
 			Response challenge = context.form()
+				.setAttribute("phoneNumber", mobileNumber)
 				.setError("smsAuthCodeInvalid")
 				.createForm("login-sms.ftl");
 			context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, challenge);
@@ -157,5 +162,16 @@ public class SmsAuthenticator implements Authenticator, CredentialValidator<SmsA
 	@Override
 	public SmsAuthCredentialProvider getCredentialProvider(KeycloakSession session) {
 		return (SmsAuthCredentialProvider)session.getProvider(CredentialProvider.class, SmsAuthCredentialProviderFactory.PROVIDER_ID);
+	}
+
+	private String getMobileNumber(AuthenticationFlowContext context) {
+		Optional<CredentialModel> model = context.getUser().credentialManager()
+			.getStoredCredentialsByTypeStream(SmsAuthCredentialModel.TYPE).findFirst();
+		try {
+			return JsonSerialization.readValue(model.orElseThrow().getCredentialData(), SmsAuthCredentialData.class).getMobileNumber();
+		} catch (IOException e) {
+			logger.warn(e.getMessage(), e);
+			return null;
+		}
 	}
 }

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_ca.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_ca.properties
@@ -3,6 +3,7 @@ smsAuthText=El vostre codi SMS és %1$s i és vàlid durant %2$d minuts.
 smsAuthTitle=Codi SMS
 smsAuthLabel=Codi SMS
 smsAuthInstruction=Introduïu el codi que s’ha enviat al vostre dispositiu.
+smsAuthInstructionWithPhone=Introduïu el codi que hem enviat a {0}.
 
 smsAuthSmsNotSent=No s’ha pogut enviar el SMS, perquè {0}
 smsAuthCodeExpired=El codi SMS ha caducat.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_de.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_de.properties
@@ -3,6 +3,7 @@ smsAuthText=Ihr SMS Code lautet %1$s und ist gültig für %2$d Minuten.
 smsAuthTitle=SMS Code
 smsAuthLabel=SMS Code
 smsAuthInstruction=Geben Sie den SMS Code ein, den wir an Ihr Gerät gesendet haben.
+smsAuthInstructionWithPhone=Geben Sie den Code ein, den wir an {0} gesendet haben.
 
 smsAuthSmsNotSent=Die SMS konnte nicht gesendet werden. Grund: {0}
 smsAuthCodeExpired=Der SMS Code ist abgelaufen.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_en.properties
@@ -3,6 +3,7 @@ smsAuthText=Your SMS code is %1$s and is valid for %2$d minutes.
 smsAuthTitle=SMS Code
 smsAuthLabel=SMS Code
 smsAuthInstruction=Enter the code we sent to your device.
+smsAuthInstructionWithPhone=Enter the code we sent to {0}.
 
 smsAuthSmsNotSent=The SMS could not be sent, because of {0}
 smsAuthCodeExpired=The SMS code has expired.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_es.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_es.properties
@@ -3,6 +3,7 @@ smsAuthText=Su código SMS es %1$s y es válido durante %2$d minutos.
 smsAuthTitle=Código SMS
 smsAuthLabel=Código SMS
 smsAuthInstruction=Introduzca el código que se ha enviado a su dispositivo.
+smsAuthInstructionWithPhone=Introduzca el código que hemos enviado a {0}.
 
 smsAuthSmsNotSent=El SMS no pudo ser enviado, porque {0}
 smsAuthCodeExpired=El código SMS ha caducado.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_fi.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_fi.properties
@@ -3,6 +3,7 @@ smsAuthText=Vahvistuskoodisi on %1$s ja se on voimassa %2$d minuuttia.
 smsAuthTitle=Vahvistuskoodi
 smsAuthLabel=Vahvistuskoodi
 smsAuthInstruction=Syötä koodi, jonka lähetimme laitteeseesi.
+smsAuthInstructionWithPhone=Syötä koodi, jonka lähetimme numeroon {0}.
 
 smsAuthSmsNotSent=Tekstiviestiä ei voitu lähettää, koska {0}
 smsAuthCodeExpired=Vahvistuskoodi on vanhentunut.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_fr.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_fr.properties
@@ -3,6 +3,7 @@ smsAuthText=Votre code de vérification est %1$s et est valide pendant %2$d minu
 smsAuthTitle=Code de vérification par SMS
 smsAuthLabel=Code de vérification
 smsAuthInstruction=Entrez le code que nous avons envoyé à votre appareil.
+smsAuthInstructionWithPhone=Entrez le code que nous avons envoyé au {0}.
 
 smsAuthSmsNotSent=Le SMS n'a pas pu être envoyé en raison de {0}
 smsAuthCodeExpired=Le code de vérification a expiré.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_it.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_it.properties
@@ -3,6 +3,7 @@ smsAuthText=Il tuo codice SMS è %1$s ed è valido per %2$d minuti.
 smsAuthTitle=Codice SMS
 smsAuthLabel=Codice SMS
 smsAuthInstruction=Inserisci il codice che abbiamo inviato al tuo dispositivo.
+smsAuthInstructionWithPhone=Inserisci il codice che abbiamo inviato a {0}.
 
 smsAuthSmsNotSent=L''SMS non può essere inviato, a causa di {0}
 smsAuthCodeExpired=Il codice SMS è scaduto.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_nl.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_nl.properties
@@ -3,6 +3,7 @@ smsAuthText=Uw SMS-code is %1$s en is geldig voor %2$d minuten.
 smsAuthTitle=SMS-code
 smsAuthLabel=SMS-code
 smsAuthInstruction=Voer de code in die we naar uw apparaat hebben gestuurd.
+smsAuthInstructionWithPhone=Voer de code in die we naar {0} hebben gestuurd.
 
 smsAuthSmsNotSent=De SMS kon niet worden verzonden vanwege {0}
 smsAuthCodeExpired=De SMS-code is verlopen.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_pl.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_pl.properties
@@ -3,6 +3,7 @@ smsAuthText=Twój kod SMS to %1$s i jest ważny przez %2$d minut.
 smsAuthTitle=Kod SMS
 smsAuthLabel=Kod SMS
 smsAuthInstruction=Wpisz kod SMS, który wysłaliśmy na twoje urządzenie.
+smsAuthInstructionWithPhone=Wpisz kod SMS, który wysłaliśmy na numer {0}.
 
 smsAuthSmsNotSent=Nie udało się wysłać SMS-a. Powód: {0}
 smsAuthCodeExpired=Kod SMS wygasł.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_ru.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_ru.properties
@@ -3,6 +3,7 @@ smsAuthText=Ваш SMS-код: %1$s. Код действителен %2$d мин
 smsAuthTitle=SMS-код
 smsAuthLabel=SMS-код
 smsAuthInstruction=Введите код, который мы отправили на ваше устройство.
+smsAuthInstructionWithPhone=Введите код, который мы отправили на номер {0}.
 
 smsAuthSmsNotSent=Не удалось отправить SMS. Причина: {0}
 smsAuthCodeExpired=Срок действия SMS-кода истёк.

--- a/sms-authenticator/src/main/resources/theme-resources/templates/login-sms.ftl
+++ b/sms-authenticator/src/main/resources/theme-resources/templates/login-sms.ftl
@@ -25,6 +25,11 @@
 			</div>
 		</form>
 	<#elseif section = "info" >
-		${msg("smsAuthInstruction")}
+		<#if phoneNumber?? && phoneNumber?has_content>
+			<#assign maskedPhone = phoneNumber[0..2] + phoneNumber[3..phoneNumber?length-5]?replace(".", "*") + phoneNumber[phoneNumber?length-4..]>
+			${msg("smsAuthInstructionWithPhone", maskedPhone)}
+		<#else>
+			${msg("smsAuthInstruction")}
+		</#if>
 	</#if>
 </@layout.registrationLayout>


### PR DESCRIPTION
## Summary

Pass the user's phone number to the FreeMarker template as a `phoneNumber` attribute, allowing the template to display a masked version of the number on the SMS code entry page.

## Motivation

Currently, when a user is prompted to enter an SMS code, the page shows a generic message like "Enter the code we sent to your device." The user has no way to know **which** phone number received the SMS. This leads to:

- **Confusion** when a user has changed phone numbers or has multiple numbers linked
- **Increased support tickets** — users who don't receive the code cannot tell if it was sent to a wrong/outdated number
- **Poor UX** compared to industry standards (Google, Microsoft, banks all show a masked phone number)

## Changes

### `SmsAuthenticator.java`
- Added `.setAttribute("phoneNumber", mobileNumber)` when rendering the form in `authenticate()` method
- Added `.setAttribute("phoneNumber", mobileNumber)` when re-rendering the form on invalid code in `action()` method
- Extracted `getMobileNumber(context)` private helper to avoid code duplication

### `login-sms.ftl`
- Added conditional logic to display the masked phone number when available
- Default masking: shows first 3 chars + last 4 chars, everything else replaced with `*` (e.g., `+79*****4567`)
- Falls back to the generic instruction message if `phoneNumber` is not available

### Message bundles (all 10 locales)
- Added `smsAuthInstructionWithPhone` key with `{0}` placeholder for the masked number
- Languages: EN, RU, DE, CA, ES, FI, FR, IT, NL, PL

## Template masking examples

The default template masks the number as `+79*****4567`. Administrators can customize the masking by overriding the template in their Keycloak theme:

**Show only last 4 digits:**
```ftl
<#assign maskedPhone = "***" + phoneNumber[phoneNumber?length-4..]>
```

**Show country code + last 2 digits:**
```ftl
<#assign maskedPhone = phoneNumber[0..1] + "********" + phoneNumber[phoneNumber?length-2..]>
```

**No masking (full number):**
```ftl
${msg("smsAuthInstructionWithPhone", phoneNumber)}
```

## Backward compatibility

This change is fully backward compatible:
- The template gracefully falls back to the original `smsAuthInstruction` message if `phoneNumber` is not set
- No configuration changes required
- No breaking API changes

