### PR TITLE
feat(sms): resolve API secret via Keycloak vault

### DIFF
--- a/sms-authenticator/README.md
+++ b/sms-authenticator/README.md
@@ -30,6 +30,7 @@ from the original authenticator provider [documentation](https://www.keycloak.or
    1. `Put API Secret Token in Authorization Header`: If set, API Secret will be sent as Authorization Header, 'API Secret Token Attribute' and 'Basic Auth Username' will be ignored.
    1. `API Secret Token Attribute (optional)`: Name of attribute that contains your API token/secret. In some APIs the secret is already configured in the path. In this case, this can be left empty.
    1. `API Secret (optional)`: Your API secret. If a Basic Auth user is set, this will be the Basic Auth password. If `API Secret Token Attribute` is set, this secret will be sent as the value to the given attribute name.
+      Instead of a plaintext value you may reference a [Keycloak vault](https://www.keycloak.org/server/vault) secret, e.g. `${vault.smsApiSecret}`. The reference is resolved at send time, so the secret is never stored in the Keycloak database.
    1. `Basic Auth Username (optional)`: If set, Basic Auth will be performed. Leave empty if not required.
    1. `Message Attribute`: The attribute that contains the SMS message text. For many APIs (i.e. GTX Messaging, SMS Eagle) this is `text`.
    1. `Receiver Phone Number Attribute`: The attribute that contains the receiver phone number. For many APIs (i.e. GTX Messaging, SMS Eagle) this is `to`.

--- a/sms-authenticator/pom.xml
+++ b/sms-authenticator/pom.xml
@@ -48,6 +48,22 @@
 			<artifactId>libphonenumber</artifactId>
 			<version>9.0.30</version>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>5.15.2</version>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
 
     <build>

--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/PhoneValidationRequiredAction.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/PhoneValidationRequiredAction.java
@@ -40,6 +40,7 @@ import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.theme.Theme;
 
 import java.util.Locale;
+import java.util.Map;
 import jakarta.ws.rs.core.Response;
 
 public class PhoneValidationRequiredAction implements RequiredActionProvider, CredentialRegistrator {
@@ -76,7 +77,8 @@ public class PhoneValidationRequiredAction implements RequiredActionProvider, Cr
 			String smsAuthText = theme.getEnhancedMessages(realm,locale).getProperty("smsAuthText");
 			String smsText = String.format(smsAuthText, code, Math.floorDiv(ttl, 60));
 
-			SmsServiceFactory.get(config.getConfig()).send(mobileNumber, smsText);
+			Map<String, String> smsConfig = VaultConfigSecrets.resolve(context.getSession(), config.getConfig(), SmsAuthenticatorFactory.CONFIG_APITOKEN);
+			SmsServiceFactory.get(smsConfig).send(mobileNumber, smsText);
 
 			Response challenge = context.form()
 				.setAttribute("realm", realm)

--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticator.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticator.java
@@ -51,6 +51,7 @@ import java.util.Optional;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class SmsAuthenticator implements Authenticator, CredentialValidator<SmsAuthCredentialProvider> {
 
@@ -87,7 +88,8 @@ public class SmsAuthenticator implements Authenticator, CredentialValidator<SmsA
 			String smsAuthText = theme.getEnhancedMessages(realm,locale).getProperty("smsAuthText");
 			String smsText = String.format(smsAuthText, code, Math.floorDiv(ttl, 60));
 
-			SmsServiceFactory.get(config.getConfig()).send(mobileNumber, smsText);
+			Map<String, String> smsConfig = VaultConfigSecrets.resolve(session, config.getConfig(), SmsAuthenticatorFactory.CONFIG_APITOKEN);
+			SmsServiceFactory.get(smsConfig).send(mobileNumber, smsText);
 
 			context.challenge(context.form().setAttribute("realm", realm).createForm(TPL_CODE));
 		} catch (Exception e) {

--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorFactory.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorFactory.java
@@ -36,6 +36,7 @@ import java.util.List;
 public class SmsAuthenticatorFactory implements AuthenticatorFactory {
 
 	public static final String PROVIDER_ID = "mobile-number-authenticator";
+	public static final String CONFIG_APITOKEN = "apitoken";
 	private static final SmsAuthenticator SINGLETON = new SmsAuthenticator();
 
 
@@ -83,7 +84,7 @@ public class SmsAuthenticatorFactory implements AuthenticatorFactory {
 			new ProviderConfigProperty("urlencode", "URL encode data", "By default send a JSON in HTTP POST body. You can URL encode the data instead.", ProviderConfigProperty.BOOLEAN_TYPE, false),
 			new ProviderConfigProperty("apiTokenInHeader", "Put API Secret Token in Authorization Header", "If set, API Secret will be sent as Authorization Header, 'API Secret Token Attribute' and 'Basic Auth Username' will be ignored.", ProviderConfigProperty.BOOLEAN_TYPE, false),
 			new ProviderConfigProperty("apitokenattribute", "API Secret Token Attribute (optional)", "Name of attribute that contains your API token/secret. In some APIs the secret is already configured in the path. In this case, this can be left empty.", ProviderConfigProperty.STRING_TYPE, ""),
-			new ProviderConfigProperty("apitoken", "API Secret (optional)", "Your API secret. If a Basic Auth user is set, this will be the Basic Auth password.", ProviderConfigProperty.STRING_TYPE, "changeme"),
+			new ProviderConfigProperty(CONFIG_APITOKEN, "API Secret (optional)", "Your API secret. If a Basic Auth user is set, this will be the Basic Auth password. May reference a Keycloak vault secret, e.g. ${vault.smsApiSecret}.", ProviderConfigProperty.STRING_TYPE, "changeme"),
 			new ProviderConfigProperty("apiuser", "Basic Auth Username (optional)", "If set, Basic Auth will be performed. Leave empty if not required.", ProviderConfigProperty.STRING_TYPE, ""),
 			new ProviderConfigProperty("messageattribute", "Message Attribute", "The attribute that contains the SMS message text.", ProviderConfigProperty.STRING_TYPE, "text"),
 			new ProviderConfigProperty("receiverattribute", "Receiver Phone Number Attribute", "The attribute that contains the receiver phone number.", ProviderConfigProperty.STRING_TYPE, "to"),

--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/VaultConfigSecrets.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/VaultConfigSecrets.java
@@ -1,0 +1,37 @@
+package netzbegruenung.keycloak.authenticator;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.vault.VaultStringSecret;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Resolves {@code ${vault.<key>}} config references through Keycloak's vault, keeping secrets out of the database. */
+final class VaultConfigSecrets {
+
+	private VaultConfigSecrets() {
+	}
+
+	/**
+	 * Resolves the given {@code secretKeys} through the vault and returns the updated config; keys the
+	 * caller doesn't list are left untouched. Non-vault values resolve to themselves and an
+	 * unresolvable reference falls back to the literal (Keycloak logs a warning). The input map is
+	 * never mutated.
+	 */
+	static Map<String, String> resolve(KeycloakSession session, Map<String, String> config, String... secretKeys) {
+		Map<String, String> resolved = null;
+		for (String key : secretKeys) {
+			String value = config.get(key);
+			if (value == null || value.isEmpty()) {
+				continue;
+			}
+			try (VaultStringSecret secret = session.vault().getStringSecret(value)) {
+				if (resolved == null) {
+					resolved = new HashMap<>(config);
+				}
+				resolved.put(key, secret.get().orElse(value));
+			}
+		}
+		return resolved == null ? config : resolved;
+	}
+}

--- a/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/VaultConfigSecretsTest.java
+++ b/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/VaultConfigSecretsTest.java
@@ -1,0 +1,110 @@
+package netzbegruenung.keycloak.authenticator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.vault.VaultStringSecret;
+import org.keycloak.vault.VaultTranscriber;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+public class VaultConfigSecretsTest {
+
+	private static final String API_TOKEN = "apitoken";
+
+	private KeycloakSession session;
+	private VaultTranscriber vault;
+	private VaultStringSecret secret;
+
+	@BeforeEach
+	public void setup() {
+		session = mock(KeycloakSession.class);
+		vault = mock(VaultTranscriber.class);
+		secret = mock(VaultStringSecret.class);
+	}
+
+	@Test
+	public void resolvesRequestedKeyFromVault() {
+		when(session.vault()).thenReturn(vault);
+		when(vault.getStringSecret("${vault.sms_api_secret}")).thenReturn(secret);
+		when(secret.get()).thenReturn(Optional.of("s3cr3t"));
+
+		Map<String, String> resolved = VaultConfigSecrets.resolve(
+			session, Map.of("apiurl", "https://sms.example", API_TOKEN, "${vault.sms_api_secret}"), API_TOKEN);
+
+		assertEquals("s3cr3t", resolved.get(API_TOKEN), "requested key is resolved from the vault");
+		assertEquals("https://sms.example", resolved.get("apiurl"), "other config is untouched");
+		verify(secret).close();
+	}
+
+	@Test
+	public void resolvesMultipleRequestedKeys() {
+		VaultStringSecret second = mock(VaultStringSecret.class);
+		when(session.vault()).thenReturn(vault);
+		when(vault.getStringSecret("${vault.token}")).thenReturn(secret);
+		when(secret.get()).thenReturn(Optional.of("tok"));
+		when(vault.getStringSecret("${vault.pass}")).thenReturn(second);
+		when(second.get()).thenReturn(Optional.of("pw"));
+
+		Map<String, String> resolved = VaultConfigSecrets.resolve(
+			session, Map.of(API_TOKEN, "${vault.token}", "apipassword", "${vault.pass}"), API_TOKEN, "apipassword");
+
+		assertEquals("tok", resolved.get(API_TOKEN));
+		assertEquals("pw", resolved.get("apipassword"));
+	}
+
+	@Test
+	public void passesThroughNonVaultValue() {
+		// A non-vault value resolves to itself in Keycloak's transcriber.
+		when(session.vault()).thenReturn(vault);
+		when(vault.getStringSecret("plain-token")).thenReturn(secret);
+		when(secret.get()).thenReturn(Optional.of("plain-token"));
+
+		Map<String, String> resolved = VaultConfigSecrets.resolve(session, Map.of(API_TOKEN, "plain-token"), API_TOKEN);
+
+		assertEquals("plain-token", resolved.get(API_TOKEN), "plaintext value stays usable");
+	}
+
+	@Test
+	public void fallsBackToLiteralWhenVaultSecretMissing() {
+		// An unresolvable vault expression yields an empty Optional; keep the literal, not null.
+		when(session.vault()).thenReturn(vault);
+		when(vault.getStringSecret("${vault.missing}")).thenReturn(secret);
+		when(secret.get()).thenReturn(Optional.empty());
+
+		Map<String, String> resolved = VaultConfigSecrets.resolve(session, Map.of(API_TOKEN, "${vault.missing}"), API_TOKEN);
+
+		assertEquals("${vault.missing}", resolved.get(API_TOKEN), "unresolved expression falls back to the literal");
+	}
+
+	@Test
+	public void emptyValueIsNoOp() {
+		Map<String, String> config = Map.of("apiurl", "https://sms.example", API_TOKEN, "");
+
+		assertEquals(config, VaultConfigSecrets.resolve(session, config, API_TOKEN));
+		verifyNoInteractions(session);
+	}
+
+	@Test
+	public void missingKeyIsNoOp() {
+		Map<String, String> config = Map.of("apiurl", "https://sms.example");
+
+		assertEquals(config, VaultConfigSecrets.resolve(session, config, API_TOKEN));
+		verifyNoInteractions(session);
+	}
+
+	@Test
+	public void noRequestedKeysIsNoOp() {
+		Map<String, String> config = Map.of(API_TOKEN, "${vault.sms_api_secret}");
+
+		assertEquals(config, VaultConfigSecrets.resolve(session, config));
+		verifyNoInteractions(session);
+	}
+}


### PR DESCRIPTION
## Summary

Lets the SMS authenticator's **API Secret** be a [Keycloak vault](https://www.keycloak.org/server/vault) reference (e.g. `${vault.smsApiSecret}`) instead of a plaintext value. The reference is resolved at send time, so the secret is never written to the Keycloak database.

## Motivation

Today the API secret is stored verbatim in the authenticator config, which means it's persisted in plaintext in the Keycloak database (and shows up in realm exports). Operators who keep secrets in a vault (file/KV) have no way to reference them here. They're forced to paste the raw secret into the flow config. This change lets the config hold only a `${vault.…}` reference and resolves it through Keycloak's standard vault SPI when sending.

## Changes

- Add `VaultConfigSecrets.resolve(session, config, keys…)` — resolves the given config keys through `session.vault()`. It's schema-agnostic: the caller passes which keys hold secrets.
- Route both SMS send paths through it:
  - `SmsAuthenticator` — the 2FA login challenge.
  - `PhoneValidationRequiredAction` — the confirmation SMS when a user registers their number.
- Add a `CONFIG_APITOKEN` constant on `SmsAuthenticatorFactory` as the single source of truth for the key, and note vault support in the property description.
- Unit tests for the resolver and README docs for the feature.

## Behaviour / backward compatibility

- **Fully backward compatible.** A plaintext value is not a vault expression, so it resolves to itself, existing configs keep working unchanged.
- A `${vault.…}` reference that can't be resolved falls back to the literal value (Keycloak logs a warning) rather than throwing, so a misconfiguration surfaces at the SMS API instead of breaking the flow.
- The input config map is never mutated; a copy is made only when a secret is actually resolved.

## Usage

Configure the vault (e.g. `KC_VAULT=file`, `KC_VAULT_DIR=…`), then set the authenticator's **API Secret** to a reference such as `${vault.smsApiSecret}` instead of the raw token. See the [Keycloak vault docs](https://www.keycloak.org/server/vault) for vault setup and key/file naming.

## Testing

- Unit tests (`VaultConfigSecretsTest`, 7 cases): vault resolution, multiple keys, non-vault passthrough, unresolved-reference fallback, and empty/missing/no-key no-ops.

---

*Disclosure: this change was developed with AI assistance. I have manually reviewed, tested, and verified all of it.*