### PR TITLE
feat(sms-authenticator): Allow custom HTTP header name for API token authentication (use apitokenattribute)

### DIFF
--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/gateway/ApiSmsService.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/gateway/ApiSmsService.java
@@ -117,8 +117,9 @@ public class ApiSmsService implements SmsService{
 			}
 
 			if (apiTokenInHeader) {
-				request = requestBuilder.setHeader("Authorization", apitoken).build();
-			}else if (apiuser != null && !apiuser.isEmpty()) {
+				String headerName = (apitokenattribute != null && !apitokenattribute.isBlank()) ? apitokenattribute : "Authorization";
+				request = requestBuilder.setHeader(headerName, apitoken).build();
+			} else if (apiuser != null && !apiuser.isEmpty()) {
 				request = requestBuilder.setHeader("Authorization", getAuthHeader(apiuser, apitoken)).build();
 			} else {
 				request = requestBuilder.build();


### PR DESCRIPTION
### Description
Currently, when `apiTokenInHeader` is set to `true`, the HTTP header name is hardcoded to `"Authorization"` in `ApiSmsService.java`. 

There are SMS gateways/APIs that require a custom header name, such as `x-api-key`, instead of the standard `Authorization` header.

### Proposed Solution
We can use the already existing configuration property `apitokenattribute` as a fallback. If it is configured and not blank, it should be used as the HTTP header name. If it is empty, it will fall back to `"Authorization"` to maintain backward compatibility.