### PR TITLE
Lock out repeated invalid SMS codes via brute-force protector

### DIFF
--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticator.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticator.java
@@ -33,6 +33,10 @@ import org.keycloak.authentication.AuthenticationFlowError;
 import org.keycloak.authentication.Authenticator;
 import org.keycloak.authentication.RequiredActionFactory;
 import org.keycloak.authentication.RequiredActionProvider;
+import org.keycloak.events.Errors;
+import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.services.managers.BruteForceProtector;
+import org.keycloak.services.messages.Messages;
 import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.credential.CredentialModel;
 import org.keycloak.credential.CredentialProvider;
@@ -63,6 +67,11 @@ public class SmsAuthenticator implements Authenticator, CredentialValidator<SmsA
 		KeycloakSession session = context.getSession();
 		UserModel user = context.getUser();
 		RealmModel realm = context.getRealm();
+
+		// Do not issue a new code to a user already locked out by brute-force protection.
+		if (isDisabledByBruteForce(context)) {
+			return;
+		}
 
 		Optional<CredentialModel> model = context.getUser().credentialManager().getStoredCredentialsByTypeStream(SmsAuthCredentialModel.TYPE).findFirst();
 		String mobileNumber;
@@ -99,6 +108,11 @@ public class SmsAuthenticator implements Authenticator, CredentialValidator<SmsA
 
 	@Override
 	public void action(AuthenticationFlowContext context) {
+		// Reject further attempts once brute-force protection has temporarily disabled the account.
+		if (isDisabledByBruteForce(context)) {
+			return;
+		}
+
 		String enteredCode = context.getHttpRequest().getDecodedFormParameters().getFirst("code");
 
 		AuthenticationSessionModel authSession = context.getAuthenticationSession();
@@ -124,6 +138,9 @@ public class SmsAuthenticator implements Authenticator, CredentialValidator<SmsA
 		} else {
 			// invalid
 			context.getEvent().user(context.getUser()).error("invalid_user_credentials");
+			// Record the failure with the realm brute-force protector so repeated wrong SMS codes are
+			// rate-limited / locked out, the same way the built-in OTP form is protected.
+			recordBruteForceFailure(context);
 			Response challenge = context.form()
 				.setError("smsAuthCodeInvalid")
 				.createForm("login-sms.ftl");
@@ -148,6 +165,40 @@ public class SmsAuthenticator implements Authenticator, CredentialValidator<SmsA
 
 	public List<RequiredActionFactory> getRequiredActions(KeycloakSession session) {
 		return Collections.singletonList((PhoneNumberRequiredActionFactory)session.getKeycloakSessionFactory().getProviderFactory(RequiredActionProvider.class, PhoneNumberRequiredAction.PROVIDER_ID));
+	}
+
+	/**
+	 * Returns true (and fails the flow) if brute-force protection has temporarily disabled the user.
+	 * The stock SMS authenticator never consulted brute-force state, so SMS codes could be guessed
+	 * without limit; this brings it in line with the built-in OTP form.
+	 */
+	private boolean isDisabledByBruteForce(AuthenticationFlowContext context) {
+		RealmModel realm = context.getRealm();
+		UserModel user = context.getUser();
+		if (realm.isBruteForceProtected() && user != null
+				&& context.getSession().getProvider(BruteForceProtector.class)
+					.isTemporarilyDisabled(context.getSession(), realm, user)) {
+			context.getEvent().user(user).error(Errors.USER_TEMPORARILY_DISABLED);
+			context.failureChallenge(AuthenticationFlowError.USER_TEMPORARILY_DISABLED,
+				context.form().setError(Messages.ACCOUNT_TEMPORARILY_DISABLED)
+					.createErrorPage(Response.Status.UNAUTHORIZED));
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Records a failed second-factor attempt with the realm brute-force protector, mirroring the
+	 * framework's own AuthenticationProcessor.logFailure() call so failures count toward lockout.
+	 */
+	private void recordBruteForceFailure(AuthenticationFlowContext context) {
+		RealmModel realm = context.getRealm();
+		UserModel user = context.getUser();
+		if (realm.isBruteForceProtected() && user != null) {
+			context.getSession().getProvider(BruteForceProtector.class).failedLogin(
+				realm, user, context.getConnection(), context.getUriInfo(),
+				AuthenticationManager.getAuthenticationCategory(context.getSession(), context.getExecution().getId()));
+		}
 	}
 
 	@Override


### PR DESCRIPTION
The SMS 2FA authenticator validated wrong codes but never reported the failure to Keycloak's BruteForceProtector, so an SMS code could be guessed without limit or lockout.  An attacker who already holds the user's password could brute-force the N-digit code within its TTL with no rate limiting.

action() now records each invalid code via BruteForceProtector.failedLogin(), mirroring AuthenticationProcessor.logFailure(), so failures count toward the realm's brute-force thresholds, and rejects further attempts once the account is temporarily disabled. authenticate() also refuses to issue a new code to a locked-out user.