### PR TITLE
Make SMS authenticator vault-aware

### DIFF
--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/PhoneValidationRequiredAction.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/PhoneValidationRequiredAction.java
@@ -76,7 +76,7 @@ public class PhoneValidationRequiredAction implements RequiredActionProvider, Cr
 			String smsAuthText = theme.getEnhancedMessages(realm,locale).getProperty("smsAuthText");
 			String smsText = String.format(smsAuthText, code, Math.floorDiv(ttl, 60));
 
-			SmsServiceFactory.get(config.getConfig()).send(mobileNumber, smsText);
+			SmsServiceFactory.get(config.getConfig(), context.getSession()).send(mobileNumber, smsText);
 
 			Response challenge = context.form()
 				.setAttribute("realm", realm)

--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticator.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticator.java
@@ -87,7 +87,7 @@ public class SmsAuthenticator implements Authenticator, CredentialValidator<SmsA
 			String smsAuthText = theme.getEnhancedMessages(realm,locale).getProperty("smsAuthText");
 			String smsText = String.format(smsAuthText, code, Math.floorDiv(ttl, 60));
 
-			SmsServiceFactory.get(config.getConfig()).send(mobileNumber, smsText);
+			SmsServiceFactory.get(config.getConfig(), session).send(mobileNumber, smsText);
 
 			context.challenge(context.form().setAttribute("realm", realm).createForm(TPL_CODE));
 		} catch (Exception e) {

--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/gateway/SmsServiceFactory.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/gateway/SmsServiceFactory.java
@@ -22,12 +22,34 @@
 package netzbegruenung.keycloak.authenticator.gateway;
 
 import org.jboss.logging.Logger;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.vault.VaultStringSecret;
+import org.keycloak.vault.VaultTranscriber;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class SmsServiceFactory {
 
 	private static final Logger logger = Logger.getLogger(SmsServiceFactory.class);
+
+	/**
+	 * Config keys whose values may be Keycloak vault references ({@code ${vault.<key>}})
+	 * and therefore must be resolved through the {@link VaultTranscriber} before use.
+	 * These are the SMS gateway credentials: the API token and, for HTTP Basic auth, the API user.
+	 */
+	private static final List<String> SECRET_KEYS = List.of("apitoken", "apiuser");
+
+	/**
+	 * Vault-aware variant: resolves any {@code ${vault.<key>}} references in the credential config
+	 * (see {@link #SECRET_KEYS}) via the session's {@link VaultTranscriber}, then builds the service.
+	 * Plain literal values pass through unchanged, so this is fully backward compatible with configs
+	 * that store the token/user inline.
+	 */
+	public static SmsService get(Map<String, String> config, KeycloakSession session) {
+		return get(resolveSecrets(config, session));
+	}
 
 	public static SmsService get(Map<String, String> config) {
 		if (Boolean.parseBoolean(config.getOrDefault("simulation", "false"))) {
@@ -36,5 +58,25 @@ public class SmsServiceFactory {
 		} else {
 			return new ApiSmsService(config);
 		}
+	}
+
+	private static Map<String, String> resolveSecrets(Map<String, String> config, KeycloakSession session) {
+		if (session == null || config == null) {
+			return config;
+		}
+		Map<String, String> resolved = new HashMap<>(config);
+		VaultTranscriber vault = session.vault();
+		for (String key : SECRET_KEYS) {
+			String value = config.get(key);
+			if (value == null || value.isEmpty()) {
+				continue;
+			}
+			// getStringSecret returns the literal value when it is not a ${vault.x} expression, and the
+			// resolved secret when it is (an empty Optional only if a referenced vault key is missing).
+			try (VaultStringSecret secret = vault.getStringSecret(value)) {
+				secret.get().ifPresent(resolvedValue -> resolved.put(key, resolvedValue));
+			}
+		}
+		return resolved;
 	}
 }


### PR DESCRIPTION
Resolve ${vault.<key>} references in the SMS gateway credentials (apitoken, apiuser) via the Keycloak VaultTranscriber before constructing the gateway, so the that an API key/secret can be sourced from Keycloak's files-vault (KC_VAULT=file) instead of being stored in realm/authenticator config. Literal values pass through unchanged, so this is fully backward compatible.

- SmsServiceFactory: add get(config, session) overload + resolveSecrets()
- SmsAuthenticator / PhoneValidationRequiredAction: pass the session through