### PR TITLE
fix(enforce-mfa): use stored credential types instead of provider SPI ids

### DIFF
--- a/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/EnforceMfaShared.java
+++ b/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/EnforceMfaShared.java
@@ -2,11 +2,10 @@ package netzbegruenung.keycloak.enforce_mfa;
 
 import org.keycloak.authentication.requiredactions.WebAuthnPasswordlessRegisterFactory;
 import org.keycloak.authentication.requiredactions.WebAuthnRegisterFactory;
-import org.keycloak.credential.OTPCredentialProviderFactory;
-import org.keycloak.credential.WebAuthnCredentialProviderFactory;
-import org.keycloak.credential.WebAuthnPasswordlessCredentialProviderFactory;
 import org.keycloak.models.Constants;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.credential.OTPCredentialModel;
+import org.keycloak.models.credential.WebAuthnCredentialModel;
 
 import java.util.List;
 import java.util.Map;
@@ -24,11 +23,11 @@ public final class EnforceMfaShared {
 	/** Same key as {@link EnforceMfaAuthenticator#CONFIG_OPTIONAL_NAME}. */
 	public static final String CONFIG_OPTIONAL_NAME = "mfaSetupOptional";
 
-	/** Credential type ids for {@link MfaCredentialConditionFactory} admin UI. */
+	/** Stored credential type ids for {@link MfaCredentialConditionFactory} admin UI (not credential provider SPI ids). */
 	public static final List<String> CREDENTIAL_TYPE_OPTIONS = List.of(
-		OTPCredentialProviderFactory.PROVIDER_ID,
-		WebAuthnCredentialProviderFactory.PROVIDER_ID,
-		WebAuthnPasswordlessCredentialProviderFactory.PROVIDER_ID,
+		OTPCredentialModel.TYPE, // "otp"
+		WebAuthnCredentialModel.TYPE_TWOFACTOR, // "webauthn"
+		WebAuthnCredentialModel.TYPE_PASSWORDLESS, // "webauthn-passwordless"
 		"email-authenticator", /* from mesutpiskin/keycloak-2fa-email-authenticator */
 		"mobile-number" /* from netzbegruenung/keycloak-mfa-plugins/sms-authenticator */
 	);

--- a/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/RequiredActionEnrollment.java
+++ b/enforce-mfa/src/main/java/netzbegruenung/keycloak/enforce_mfa/RequiredActionEnrollment.java
@@ -2,12 +2,11 @@ package netzbegruenung.keycloak.enforce_mfa;
 
 import org.keycloak.authentication.requiredactions.WebAuthnPasswordlessRegisterFactory;
 import org.keycloak.authentication.requiredactions.WebAuthnRegisterFactory;
-import org.keycloak.credential.OTPCredentialProviderFactory;
-import org.keycloak.credential.WebAuthnCredentialProviderFactory;
-import org.keycloak.credential.WebAuthnPasswordlessCredentialProviderFactory;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.credential.OTPCredentialModel;
+import org.keycloak.models.credential.WebAuthnCredentialModel;
 
 import java.util.Map;
 
@@ -17,9 +16,9 @@ import java.util.Map;
 public final class RequiredActionEnrollment {
 
 	private static final Map<String, String> CREDENTIAL_TYPE_BY_REQUIRED_ACTION_ID = Map.of(
-		UserModel.RequiredAction.CONFIGURE_TOTP.name(), OTPCredentialProviderFactory.PROVIDER_ID,
-		WebAuthnRegisterFactory.PROVIDER_ID, WebAuthnCredentialProviderFactory.PROVIDER_ID,
-		WebAuthnPasswordlessRegisterFactory.PROVIDER_ID, WebAuthnPasswordlessCredentialProviderFactory.PROVIDER_ID,
+		UserModel.RequiredAction.CONFIGURE_TOTP.name(), OTPCredentialModel.TYPE,
+		WebAuthnRegisterFactory.PROVIDER_ID, WebAuthnCredentialModel.TYPE_TWOFACTOR,
+		WebAuthnPasswordlessRegisterFactory.PROVIDER_ID, WebAuthnCredentialModel.TYPE_PASSWORDLESS,
 		"email-authenticator-setup", "email-authenticator", /* from mesutpiskin/keycloak-2fa-email-authenticator */
 		"mobile_number_config", "mobile-number", /* from netzbegruenung/keycloak-mfa-plugins/sms-authenticator */
 		"phone_validation_config", "mobile-number" /* from netzbegruenung/keycloak-mfa-plugins/sms-authenticator */


### PR DESCRIPTION
Hello @melegiul,

Fixes a [regression](https://github.com/netzbegruenung/keycloak-mfa-plugins/pull/363#issuecomment-4295968351) in mfa-credential-condition : the admin dropdown offered credential provider SPI ids (`keycloak-otp`, `keycloak-webauthn`) instead of stored credential types (`otp`, `webauthn`). Selecting them breaks UserCredentialManager.isConfiguredFor() for users with enrolled MFA.

Not blocking for existing setups : correct values can be set via the API, and realm configs using otp / webauthn keep working. Main risk is for newcomers configuring `mfa-credential-condition` through the admin UI.