### PR TITLE
fix(email-authenticator): render OTP emails through realm email theme (#386)

### DIFF
--- a/email-authenticator/README.md
+++ b/email-authenticator/README.md
@@ -30,7 +30,15 @@ Keycloak Authentication Provider implementation that sends a one-time code (OTP)
 | Time-to-live | Validity period of the OTP in seconds. | `300` |
 | Force 2FA | If no other 2FA method is configured, the user is forced to verify their email and use Email OTP. | `false` |
 
-The email subject and body are taken from the theme message bundle (keys `emailAuthSubject` and `emailAuthText`) and can be customised per realm/theme. The body supports `%1$s` (code) and `%2$d` (validity in minutes) placeholders.
+The email subject and body are rendered through the realm **email** theme (same pipeline as built-in Keycloak emails). Customize them in your email theme message bundle:
+
+| Key | Description |
+| --- | --- |
+| `emailAuthSubject` | Email subject (`{0}` = code, `{1}` = validity in minutes, optional) |
+| `emailAuthBody` | Plain-text body (`{0}` = code, `{1}` = validity in minutes) |
+| `emailAuthBodyHtml` | HTML body fragment (wrapped by `template.ftl`) |
+
+To change layout or branding, override `email/html/template.ftl` in your realm email theme.
 
 # Usage
 After the authenticator is wired into the flow, users with a verified email address automatically receive a login code on the second-factor step.

--- a/email-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/EmailAuthenticator.java
+++ b/email-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/EmailAuthenticator.java
@@ -30,7 +30,7 @@ import org.keycloak.authentication.AuthenticationFlowError;
 import org.keycloak.authentication.Authenticator;
 import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.email.EmailException;
-import org.keycloak.email.EmailSenderProvider;
+import org.keycloak.email.EmailTemplateProvider;
 import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.KeycloakSession;
@@ -38,17 +38,18 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserModel.RequiredAction;
 import org.keycloak.sessions.AuthenticationSessionModel;
-import org.keycloak.theme.Theme;
 
 import jakarta.ws.rs.core.Response;
 import java.util.Collections;
-import java.util.Locale;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class EmailAuthenticator implements Authenticator {
 
 	private static final Logger logger = Logger.getLogger(EmailAuthenticator.class);
 	static final String TPL_CODE = "login-email.ftl";
+	private static final String EMAIL_TPL_CODE = "email-auth.ftl";
 
 	@Override
 	public void authenticate(AuthenticationFlowContext context) {
@@ -73,19 +74,19 @@ public class EmailAuthenticator implements Authenticator {
 		authSession.setAuthNote("ttl", Long.toString(System.currentTimeMillis() + (ttl * 1000L)));
 
 		try {
-			Theme theme = session.theme().getTheme(Theme.Type.LOGIN);
-			Locale locale = session.getContext().resolveLocale(user);
-			String subjectTemplate = theme.getEnhancedMessages(realm, locale).getProperty("emailAuthSubject");
-			String bodyTemplate = theme.getEnhancedMessages(realm, locale).getProperty("emailAuthText");
+			int ttlMinutes = Math.floorDiv(ttl, 60);
+			Map<String, Object> attributes = new HashMap<>();
+			attributes.put("code", code);
+			attributes.put("ttl", ttlMinutes);
 
-			String subject = String.format(subjectTemplate, code, Math.floorDiv(ttl, 60));
-			String body = String.format(bodyTemplate, code, Math.floorDiv(ttl, 60));
-
-			EmailSenderProvider emailSenderProvider = session.getProvider(EmailSenderProvider.class);
-			emailSenderProvider.send(realm.getSmtpConfig(), user, subject, body, body);
+			session.getProvider(EmailTemplateProvider.class)
+				.setAuthenticationSession(authSession)
+				.setRealm(realm)
+				.setUser(user)
+				.send("emailAuthSubject", List.of(code, ttlMinutes), EMAIL_TPL_CODE, attributes);
 
 			context.challenge(context.form().setAttribute("realm", realm).createForm(TPL_CODE));
-		} catch (EmailException | java.io.IOException e) {
+		} catch (EmailException e) {
 			logger.warn("Failed to send verification email", e);
 			context.failureChallenge(AuthenticationFlowError.INTERNAL_ERROR,
 				context.form().setError("emailAuthEmailNotSent", e.getMessage())

--- a/email-authenticator/src/main/resources/theme-resources/messages/messages_de.properties
+++ b/email-authenticator/src/main/resources/theme-resources/messages/messages_de.properties
@@ -1,5 +1,6 @@
 emailAuthSubject=Ihr Anmeldecode
-emailAuthText=Ihr E-Mail-Code lautet %1$s und ist %2$d Minuten gültig.
+emailAuthBody=Ihr E-Mail-Code lautet {0} und ist {1} Minuten gültig.
+emailAuthBodyHtml=<p>Ihr E-Mail-Code lautet <strong>{0}</strong> und ist {1} Minuten gültig.</p>
 
 emailAuthTitle=E-Mail-Code
 emailAuthLabel=E-Mail-Code

--- a/email-authenticator/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/email-authenticator/src/main/resources/theme-resources/messages/messages_en.properties
@@ -1,5 +1,6 @@
 emailAuthSubject=Your login code
-emailAuthText=Your email login code is %1$s and is valid for %2$d minutes.
+emailAuthBody=Your email login code is {0} and is valid for {1} minutes.
+emailAuthBodyHtml=<p>Your email login code is <strong>{0}</strong> and is valid for {1} minutes.</p>
 
 emailAuthTitle=Email Code
 emailAuthLabel=Email Code

--- a/email-authenticator/src/main/resources/theme-resources/messages/messages_fr.properties
+++ b/email-authenticator/src/main/resources/theme-resources/messages/messages_fr.properties
@@ -1,5 +1,6 @@
 emailAuthSubject=Votre code de connexion
-emailAuthText=Votre code de connexion par e-mail est %1$s et est valable pendant %2$d minutes.
+emailAuthBody=Votre code de connexion par e-mail est {0} et est valable pendant {1} minutes.
+emailAuthBodyHtml=<p>Votre code de connexion par e-mail est <strong>{0}</strong> et est valable pendant {1} minutes.</p>
 
 emailAuthTitle=Code e-mail
 emailAuthLabel=Code e-mail

--- a/email-authenticator/src/main/resources/theme-resources/messages/messages_nl.properties
+++ b/email-authenticator/src/main/resources/theme-resources/messages/messages_nl.properties
@@ -1,5 +1,6 @@
 emailAuthSubject=Uw inlogcode
-emailAuthText=Uw e-mail-inlogcode is %1$s en is %2$d minuten geldig.
+emailAuthBody=Uw e-mail-inlogcode is {0} en is {1} minuten geldig.
+emailAuthBodyHtml=<p>Uw e-mail-inlogcode is <strong>{0}</strong> en is {1} minuten geldig.</p>
 
 emailAuthTitle=E-mailcode
 emailAuthLabel=E-mailcode

--- a/email-authenticator/src/main/resources/theme-resources/templates/html/email-auth.ftl
+++ b/email-authenticator/src/main/resources/theme-resources/templates/html/email-auth.ftl
@@ -1,0 +1,4 @@
+<#import "template.ftl" as layout>
+<@layout.emailLayout>
+${kcSanitize(msg("emailAuthBodyHtml", code, ttl))?no_esc}
+</@layout.emailLayout>

--- a/email-authenticator/src/main/resources/theme-resources/templates/text/email-auth.ftl
+++ b/email-authenticator/src/main/resources/theme-resources/templates/text/email-auth.ftl
@@ -1,0 +1,2 @@
+<#ftl output_format="plainText">
+${msg("emailAuthBody", code, ttl)}

--- a/email-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/EmailAuthenticatorTest.java
+++ b/email-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/EmailAuthenticatorTest.java
@@ -15,32 +15,28 @@ import org.junit.jupiter.api.Test;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
 import org.keycloak.email.EmailException;
-import org.keycloak.email.EmailSenderProvider;
+import org.keycloak.email.EmailTemplateProvider;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.AuthenticatorConfigModel;
-import org.keycloak.models.KeycloakContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
-import org.keycloak.models.ThemeManager;
 import org.keycloak.models.UserModel;
 import org.keycloak.sessions.AuthenticationSessionModel;
-import org.keycloak.theme.Theme;
 
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 
 import java.util.HashMap;
-import java.util.Locale;
+import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -54,9 +50,8 @@ public class EmailAuthenticatorTest {
 	private LoginFormsProvider form;
 	private RealmModel realm;
 	private KeycloakSession session;
-	private KeycloakContext keycloakContext;
 	private UserModel user;
-	private EmailSenderProvider emailSenderProvider;
+	private EmailTemplateProvider emailTemplateProvider;
 
 	@BeforeEach
 	public void setup() throws Exception {
@@ -67,9 +62,8 @@ public class EmailAuthenticatorTest {
 		form = mock(LoginFormsProvider.class);
 		realm = mock(RealmModel.class);
 		session = mock(KeycloakSession.class);
-		keycloakContext = mock(KeycloakContext.class);
 		user = mock(UserModel.class);
-		emailSenderProvider = mock(EmailSenderProvider.class);
+		emailTemplateProvider = mock(EmailTemplateProvider.class);
 
 		when(context.getAuthenticationSession()).thenReturn(authSession);
 		when(context.getHttpRequest()).thenReturn(request);
@@ -78,23 +72,15 @@ public class EmailAuthenticatorTest {
 		when(context.getSession()).thenReturn(session);
 		when(context.getUser()).thenReturn(user);
 
-		when(session.getProvider(EmailSenderProvider.class)).thenReturn(emailSenderProvider);
-		when(session.getContext()).thenReturn(keycloakContext);
-		when(keycloakContext.resolveLocale(user)).thenReturn(Locale.ENGLISH);
-
-		ThemeManager themeManager = mock(ThemeManager.class);
-		Theme theme = mock(Theme.class);
-		when(session.theme()).thenReturn(themeManager);
-		when(themeManager.getTheme(Theme.Type.LOGIN)).thenReturn(theme);
-		Properties messages = new Properties();
-		messages.setProperty("emailAuthSubject", "Your login code");
-		messages.setProperty("emailAuthText", "Code: %1$s valid %2$d min");
-		when(theme.getEnhancedMessages(eq(realm), any(Locale.class))).thenReturn(messages);
+		when(session.getProvider(EmailTemplateProvider.class)).thenReturn(emailTemplateProvider);
+		when(emailTemplateProvider.setAuthenticationSession(any())).thenReturn(emailTemplateProvider);
+		when(emailTemplateProvider.setRealm(any())).thenReturn(emailTemplateProvider);
+		when(emailTemplateProvider.setUser(any())).thenReturn(emailTemplateProvider);
 
 		when(user.getEmail()).thenReturn("test@example.com");
 		when(user.isEmailVerified()).thenReturn(true);
 
-		when(form.setAttribute(anyString(), any())).thenReturn(form);
+		when(form.setAttribute(any(), any())).thenReturn(form);
 		when(form.setError(anyString(), any())).thenReturn(form);
 		when(form.setError(anyString(), (Object[]) any())).thenReturn(form);
 		when(form.setError(anyString())).thenReturn(form);
@@ -159,6 +145,14 @@ public class EmailAuthenticatorTest {
 
 		authenticator.authenticate(context);
 
-		verify(emailSenderProvider).send(any(), eq(user), eq("Your login code"), matches("Code: \\d{6} valid 5 min"), matches("Code: \\d{6} valid 5 min"));
+		verify(emailTemplateProvider).send(
+			eq("emailAuthSubject"),
+			argThat((List<Object> subjectAttrs) ->
+				subjectAttrs.size() == 2
+					&& subjectAttrs.get(0).toString().matches("\\d{6}")
+					&& subjectAttrs.get(1).equals(5)),
+			eq("email-auth.ftl"),
+			argThat(attrs -> attrs.get("ttl").equals(5) && attrs.get("code").toString().matches("\\d{6}"))
+		);
 	}
 }


### PR DESCRIPTION
## Summary

OTP emails now use `EmailTemplateProvider` instead of `EmailSenderProvider`, so realm email theme overrides (`email/html/template.ftl`, message bundle) are applied correctly.

Fixes #386

## Breaking change

Customizations must move from the login theme key `emailAuthText` (`%1$s`, `%2$d`) to the email theme keys `emailAuthBody` / `emailAuthBodyHtml` (`{0}`, `{1}`).

Thomas