### PR TITLE
feat(yubikey-authenticator): add YubiKey OTP 2FA authenticator module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <module>app-authenticator</module>
 		<module>enforce-mfa</module>
 		<module>mfa-dev-runner</module>
+		<module>yubikey-authenticator</module>
 	</modules>
 
 	<properties>

--- a/yubikey-authenticator/README.md
+++ b/yubikey-authenticator/README.md
@@ -1,0 +1,46 @@
+# Keycloak YubiKey OTP 2FA Authenticator
+
+Keycloak Authentication Provider implementation that lets a user use a physical
+YubiKey as a second factor by typing the 44-character YubiKey OTP string (the
+long string the key "types" when touched). Validation is done against Yubico's
+validation API (Validation Protocol v2.0), either the cloud endpoint
+`https://api.yubico.com/wsapi/2.0/verify` or a self-hosted validation server.
+
+This is the classic Yubico OTP protocol, not WebAuthn/FIDO2/U2F.
+
+# Installing
+1. `mvn clean install` from the repo root.
+2. Copy `yubikey-authenticator/target/netzbegruenung.yubikey-authenticator-v26.6.5.jar`
+   into the `providers` directory of your Keycloak:
+   ```shell
+   cp netzbegruenung.yubikey-authenticator-v26.6.5.jar /path/to/keycloak/providers
+   ```
+3. Run the `build` command and restart Keycloak:
+   ```shell
+   /path/to/keycloak/bin/kc.sh build [your-additional-flags]
+   systemctl restart keycloak.service
+   ```
+
+# Setup
+1. Get a Client ID + Secret Key from https://upgrade.yubico.com/getapikey/ (or
+   from your self-hosted validation server).
+2. Navigate to your Authentication flow configuration:
+   `https://keycloak.example.com/admin/master/console/#/YOUR-REALM/authentication`.
+   Edit the `Browser flow` and add a new execution / 2FA Step
+   Add **"YubiKey Authentication (2FA)"** (last page of the executions) above or below OTP Form / WebAuthn. Set it to
+   `Alternative`.
+3. Open that execution's config. **You must set the config Alias to exactly
+   `yubikey-2fa`** — this is required so that the enrollment (Required Action)
+   step can find the Client ID / Secret Key / API URL, since it runs outside
+   the authenticator execution and has no direct handle to its config.
+   Fill in **Yubico Client ID**, **Yubico Secret Key**, and optionally override
+   **Yubico API URL** for a self-hosted server.
+4. Go to Authentication > Required Actions and make sure **"Set up YubiKey"**
+   is enabled.
+
+# Usage
+Users can enroll/remove a YubiKey in the account console at
+`/realms/<realm>/account/#/account-security/signing-in` → "YubiKey" → touch
+the key to register it; use "Remove" to delete it.
+
+At login, when prompted, touch the YubiKey to submit the OTP.

--- a/yubikey-authenticator/pom.xml
+++ b/yubikey-authenticator/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>yubikey-authenticator</artifactId>
+
+    <parent>
+        <groupId>netzbegruenung</groupId>
+        <artifactId>keycloak-mfa-tools</artifactId>
+        <version>26.6.5</version>
+    </parent>
+
+    <dependencies>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-core</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-server-spi</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-server-spi-private</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-services</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.logging</groupId>
+			<artifactId>jboss-logging</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.ws.rs</groupId>
+			<artifactId>jakarta.ws.rs-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.groupId}.${project.artifactId}-v${project.version}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/yubikey-authenticator/src/main/java/netzbegruenung/keycloak/yubikey/YubicoVerifier.java
+++ b/yubikey-authenticator/src/main/java/netzbegruenung/keycloak/yubikey/YubicoVerifier.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Netzbegruenung e.V.
+ * @author verdigado eG
+ */
+
+package netzbegruenung.keycloak.yubikey;
+
+import org.jboss.logging.Logger;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * Client for the Yubico OTP Validation Protocol v2.0 (see
+ * https://developers.yubico.com/OTP/Specifications/OTP_validation_protocol.html).
+ *
+ * This class never stores or logs the plaintext secret key.
+ */
+public final class YubicoVerifier {
+
+	private static final Logger logger = Logger.getLogger(YubicoVerifier.class);
+
+	private static final char[] NONCE_CHARS =
+		"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".toCharArray();
+
+	private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+	private static final Duration READ_TIMEOUT = Duration.ofSeconds(10);
+
+	public enum Result {
+		OK,
+		BAD_OTP,
+		REPLAYED,
+		BAD_SIGNATURE,
+		NETWORK_ERROR,
+		OTHER
+	}
+
+	private final String validationUrl;
+	private final String clientId;
+	private final byte[] secretKeyRaw;
+
+	public YubicoVerifier(String validationUrl, String clientId, String secretKeyBase64) {
+		this.validationUrl = validationUrl;
+		this.clientId = clientId;
+		this.secretKeyRaw = Base64.getDecoder().decode(secretKeyBase64);
+	}
+
+	/**
+	 * Extracts the 12-character public id (the key's stable identity) from a full
+	 * 44-character YubiKey OTP string.
+	 *
+	 * @return the 12-char public id, or null if the OTP is too short
+	 */
+	public static String yubikeyPublicId(String otp) {
+		if (otp == null || otp.length() < 12) {
+			return null;
+		}
+		return otp.substring(0, 12);
+	}
+
+	static String randomNonce() {
+		SecureRandom rng = new SecureRandom();
+		StringBuilder sb = new StringBuilder(32);
+		for (int i = 0; i < 32; i++) {
+			sb.append(NONCE_CHARS[rng.nextInt(NONCE_CHARS.length)]);
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * Computes the HMAC-SHA1 request/response signature over the given params,
+	 * sorted lexicographically by key, joined as "key=value" pairs with "&amp;"
+	 * (no URL-encoding), then Base64-encoded using standard (non URL-safe) Base64.
+	 */
+	static String yubicoSign(byte[] apiKeyRaw, SortedMap<String, String> params) {
+		String line = params.entrySet().stream()
+			.map(e -> e.getKey() + "=" + e.getValue())
+			.collect(Collectors.joining("&"));
+		try {
+			Mac mac = Mac.getInstance("HmacSHA1");
+			mac.init(new SecretKeySpec(apiKeyRaw, "HmacSHA1"));
+			byte[] sig = mac.doFinal(line.getBytes(StandardCharsets.UTF_8));
+			return Base64.getEncoder().encodeToString(sig);
+		} catch (GeneralSecurityException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 * Parses a Yubico validation server response body (one "key=value" per line,
+	 * CRLF or LF separated) into a sorted map.
+	 */
+	static SortedMap<String, String> parseResponse(String body) {
+		SortedMap<String, String> result = new TreeMap<>();
+		if (body == null) {
+			return result;
+		}
+		for (String rawLine : body.split("\r\n|\n")) {
+			String line = rawLine.trim();
+			if (line.isEmpty()) {
+				continue;
+			}
+			int idx = line.indexOf('=');
+			if (idx < 0) {
+				continue;
+			}
+			result.put(line.substring(0, idx), line.substring(idx + 1));
+		}
+		return result;
+	}
+
+	/**
+	 * Runs the full protocol against the configured validation server: signs the
+	 * request, performs the HTTP GET, then verifies the response signature, nonce
+	 * echo, OTP echo, and status.
+	 */
+	public Result verify(String otp) {
+		String nonce = randomNonce();
+
+		SortedMap<String, String> requestParams = new TreeMap<>();
+		requestParams.put("id", clientId);
+		requestParams.put("nonce", nonce);
+		requestParams.put("otp", otp);
+
+		String signature = yubicoSign(secretKeyRaw, requestParams);
+
+		String query = requestParams.entrySet().stream()
+			.map(e -> e.getKey() + "=" + java.net.URLEncoder.encode(e.getValue(), StandardCharsets.UTF_8))
+			.collect(Collectors.joining("&"))
+			+ "&h=" + java.net.URLEncoder.encode(signature, StandardCharsets.UTF_8);
+
+		String body;
+		try {
+			HttpClient client = HttpClient.newBuilder()
+				.connectTimeout(CONNECT_TIMEOUT)
+				.build();
+			HttpRequest request = HttpRequest.newBuilder()
+				.uri(URI.create(validationUrl + "?" + query))
+				.timeout(READ_TIMEOUT)
+				.GET()
+				.build();
+			HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+			body = response.body();
+		} catch (Exception e) {
+			logger.warnf(e, "YubicoVerifier: network error contacting validation server");
+			return Result.NETWORK_ERROR;
+		}
+
+		SortedMap<String, String> responseParams = parseResponse(body);
+		String receivedSignature = responseParams.remove("h");
+
+		if (receivedSignature == null) {
+			logger.error("YubicoVerifier: response missing signature");
+			return Result.BAD_SIGNATURE;
+		}
+
+		String expectedSignature = yubicoSign(secretKeyRaw, responseParams);
+		if (!expectedSignature.equals(receivedSignature)) {
+			logger.error("YubicoVerifier: response signature mismatch");
+			return Result.BAD_SIGNATURE;
+		}
+
+		if (!nonce.equals(responseParams.get("nonce"))) {
+			logger.error("YubicoVerifier: response nonce mismatch");
+			return Result.BAD_SIGNATURE;
+		}
+
+		if (!otp.equals(responseParams.get("otp"))) {
+			logger.error("YubicoVerifier: response otp mismatch");
+			return Result.BAD_SIGNATURE;
+		}
+
+		String status = responseParams.get("status");
+		if ("OK".equals(status)) {
+			return Result.OK;
+		}
+
+		logger.warnf("YubicoVerifier: validation failed with status %s", status);
+		if ("REPLAYED_OTP".equals(status) || "REPLAYED_REQUEST".equals(status)) {
+			return Result.REPLAYED;
+		}
+		if ("BAD_OTP".equals(status)) {
+			return Result.BAD_OTP;
+		}
+		if ("BAD_SIGNATURE".equals(status)) {
+			return Result.BAD_SIGNATURE;
+		}
+		return Result.OTHER;
+	}
+}

--- a/yubikey-authenticator/src/main/java/netzbegruenung/keycloak/yubikey/YubikeyAuthenticator.java
+++ b/yubikey-authenticator/src/main/java/netzbegruenung/keycloak/yubikey/YubikeyAuthenticator.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Netzbegruenung e.V.
+ * @author verdigado eG
+ */
+
+package netzbegruenung.keycloak.yubikey;
+
+import netzbegruenung.keycloak.yubikey.credentials.YubikeyCredentialModel;
+
+import org.jboss.logging.Logger;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.CredentialValidator;
+import org.keycloak.authentication.RequiredActionFactory;
+import org.keycloak.authentication.RequiredActionProvider;
+import org.keycloak.credential.CredentialProvider;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+
+import jakarta.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class YubikeyAuthenticator implements Authenticator, CredentialValidator<YubikeyCredentialProvider> {
+
+	private static final Logger logger = Logger.getLogger(YubikeyAuthenticator.class);
+	static final String TPL_CODE = "yubikey-login.ftl";
+
+	@Override
+	public void authenticate(AuthenticationFlowContext context) {
+		context.challenge(context.form().createForm(TPL_CODE));
+	}
+
+	@Override
+	public void action(AuthenticationFlowContext context) {
+		String otp = context.getHttpRequest().getDecodedFormParameters().getFirst("otp");
+
+		Map<String, String> config = getConfig(context);
+		String clientId = config.get("clientId");
+		String secretKey = config.get("secretKey");
+		String validationUrl = config.getOrDefault("validationUrl", "https://api.yubico.com/wsapi/2.0/verify");
+
+		String publicId = YubicoVerifier.yubikeyPublicId(otp);
+		if (otp == null || otp.length() != 44 || publicId == null) {
+			failInvalid(context);
+			return;
+		}
+
+		if (clientId == null || secretKey == null) {
+			logger.error("Cannot verify YubiKey OTP: missing clientId/secretKey in authenticator config");
+			context.failureChallenge(AuthenticationFlowError.INTERNAL_ERROR,
+				context.form().createErrorPage(Response.Status.INTERNAL_SERVER_ERROR));
+			return;
+		}
+
+		YubicoVerifier verifier = new YubicoVerifier(validationUrl, clientId, secretKey);
+		YubicoVerifier.Result result = verifier.verify(otp);
+
+		if (result == YubicoVerifier.Result.NETWORK_ERROR) {
+			context.failureChallenge(AuthenticationFlowError.INTERNAL_ERROR,
+				context.form().createErrorPage(Response.Status.INTERNAL_SERVER_ERROR));
+			return;
+		}
+
+		if (result != YubicoVerifier.Result.OK) {
+			failInvalid(context);
+			return;
+		}
+
+		// ownership check: confirm the public id belongs to a credential enrolled by this user
+		boolean enrolled = context.getUser().credentialManager()
+			.getStoredCredentialsByTypeStream(YubikeyCredentialModel.TYPE)
+			.map(m -> YubikeyCredentialModel.createFromModel(m).getYubikeyData().getPublicId())
+			.anyMatch(publicId::equals);
+
+		if (!enrolled) {
+			context.getEvent().user(context.getUser()).error("invalid_user_credentials");
+			Response challenge = context.form()
+				.setError("yubikeyNotEnrolled")
+				.createForm(TPL_CODE);
+			context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, challenge);
+			return;
+		}
+
+		context.success();
+	}
+
+	private void failInvalid(AuthenticationFlowContext context) {
+		context.getEvent().user(context.getUser()).error("invalid_user_credentials");
+		Response challenge = context.form()
+			.setError("yubikeyInvalid")
+			.createForm(TPL_CODE);
+		context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, challenge);
+	}
+
+	/**
+	 * Prefer the authenticator's own config; fall back to the fixed "yubikey-2fa"
+	 * config alias (used by the Required Action) if none is set on this execution.
+	 */
+	private Map<String, String> getConfig(AuthenticationFlowContext context) {
+		AuthenticatorConfigModel config = context.getAuthenticatorConfig();
+		if (config != null && config.getConfig() != null) {
+			return config.getConfig();
+		}
+		return YubikeyRequiredAction.yubikeyConfig(context.getRealm());
+	}
+
+	@Override
+	public boolean requiresUser() {
+		return true;
+	}
+
+	@Override
+	public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+		return getCredentialProvider(session).isConfiguredFor(realm, user, YubikeyCredentialModel.TYPE);
+	}
+
+	@Override
+	public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+		user.addRequiredAction(YubikeyRequiredAction.PROVIDER_ID);
+	}
+
+	public List<RequiredActionFactory> getRequiredActions(KeycloakSession session) {
+		return Collections.singletonList((YubikeyRequiredActionFactory) session.getKeycloakSessionFactory()
+			.getProviderFactory(RequiredActionProvider.class, YubikeyRequiredAction.PROVIDER_ID));
+	}
+
+	@Override
+	public void close() {
+	}
+
+	@Override
+	public YubikeyCredentialProvider getCredentialProvider(KeycloakSession session) {
+		return (YubikeyCredentialProvider) session.getProvider(CredentialProvider.class, YubikeyCredentialProviderFactory.PROVIDER_ID);
+	}
+}

--- a/yubikey-authenticator/src/main/java/netzbegruenung/keycloak/yubikey/YubikeyAuthenticatorFactory.java
+++ b/yubikey-authenticator/src/main/java/netzbegruenung/keycloak/yubikey/YubikeyAuthenticatorFactory.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Netzbegruenung e.V.
+ * @author verdigado eG
+ */
+
+package netzbegruenung.keycloak.yubikey;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.List;
+
+public class YubikeyAuthenticatorFactory implements AuthenticatorFactory {
+
+	public static final String PROVIDER_ID = "yubikey-authenticator";
+	private static final YubikeyAuthenticator SINGLETON = new YubikeyAuthenticator();
+
+	@Override
+	public String getId() {
+		return PROVIDER_ID;
+	}
+
+	@Override
+	public Authenticator create(KeycloakSession session) {
+		return SINGLETON;
+	}
+
+	private static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
+		AuthenticationExecutionModel.Requirement.REQUIRED,
+		AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+		AuthenticationExecutionModel.Requirement.DISABLED
+	};
+
+	@Override
+	public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+		return REQUIREMENT_CHOICES;
+	}
+
+	@Override
+	public boolean isConfigurable() {
+		return true;
+	}
+
+	@Override
+	public boolean isUserSetupAllowed() {
+		return true;
+	}
+
+	@Override
+	public List<ProviderConfigProperty> getConfigProperties() {
+		return List.of(
+			new ProviderConfigProperty("validationUrl", "Yubico API URL",
+				"Validation server endpoint. Default is Yubico's cloud. Point at a self-hosted YubiKey validation server if desired.",
+				ProviderConfigProperty.STRING_TYPE, "https://api.yubico.com/wsapi/2.0/verify"),
+			new ProviderConfigProperty("clientId", "Yubico Client ID",
+				"The Client ID issued by Yubico (https://upgrade.yubico.com/getapikey/). A small integer.",
+				ProviderConfigProperty.STRING_TYPE, ""),
+			new ProviderConfigProperty("secretKey", "Yubico Secret Key",
+				"The Base64 API secret issued by Yubico alongside the Client ID. Used to sign requests (HMAC-SHA1).",
+				ProviderConfigProperty.STRING_TYPE, "")
+		);
+	}
+
+	@Override
+	public String getHelpText() {
+		return "Validates a YubiKey OTP against the Yubico validation API.";
+	}
+
+	@Override
+	public String getDisplayType() {
+		return "YubiKey Authentication (2FA)";
+	}
+
+	@Override
+	public String getReferenceCategory() {
+		return "yubikey";
+	}
+
+	@Override
+	public void init(Config.Scope config) {
+	}
+
+	@Override
+	public void postInit(KeycloakSessionFactory factory) {
+	}
+
+	@Override
+	public void close() {
+	}
+
+}

--- a/yubikey-authenticator/src/main/java/netzbegruenung/keycloak/yubikey/YubikeyCredentialProvider.java
+++ b/yubikey-authenticator/src/main/java/netzbegruenung/keycloak/yubikey/YubikeyCredentialProvider.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Netzbegruenung e.V.
+ * @author verdigado eG
+ */
+
+package netzbegruenung.keycloak.yubikey;
+
+import netzbegruenung.keycloak.yubikey.credentials.YubikeyCredentialModel;
+import org.keycloak.common.util.Time;
+import org.keycloak.credential.CredentialInput;
+import org.keycloak.credential.CredentialInputUpdater;
+import org.keycloak.credential.CredentialInputValidator;
+import org.keycloak.credential.CredentialModel;
+import org.keycloak.credential.CredentialProvider;
+import org.keycloak.credential.CredentialTypeMetadata;
+import org.keycloak.credential.CredentialTypeMetadataContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+
+import java.util.stream.Stream;
+
+public class YubikeyCredentialProvider implements CredentialProvider<YubikeyCredentialModel>, CredentialInputValidator, CredentialInputUpdater {
+
+	protected final KeycloakSession session;
+
+	public YubikeyCredentialProvider(KeycloakSession session) {
+		this.session = session;
+	}
+
+	@Override
+	public boolean isValid(RealmModel realm, UserModel user, CredentialInput input) {
+		// Real validation happens against the live Yubico API in the Authenticator,
+		// which does not go through this generic credential-input path.
+		return false;
+	}
+
+	@Override
+	public boolean supportsCredentialType(String credentialType) {
+		return getType().equals(credentialType);
+	}
+
+	@Override
+	public boolean isConfiguredFor(RealmModel realm, UserModel user, String credentialType) {
+		if (!supportsCredentialType(credentialType)) return false;
+		return user.credentialManager().getStoredCredentialsByTypeStream(credentialType).findAny().isPresent();
+	}
+
+	@Override
+	public CredentialModel createCredential(RealmModel realm, UserModel user, YubikeyCredentialModel credentialModel) {
+		credentialModel.setCreatedDate(Time.currentTimeMillis());
+		return user.credentialManager().createStoredCredential(credentialModel);
+	}
+
+	@Override
+	public boolean updateCredential(RealmModel realm, UserModel user, CredentialInput input) {
+		return false;
+	}
+
+	@Override
+	public boolean deleteCredential(RealmModel realm, UserModel user, String credentialId) {
+		return user.credentialManager().removeStoredCredentialById(credentialId);
+	}
+
+	@Override
+	public YubikeyCredentialModel getCredentialFromModel(CredentialModel model) {
+		return YubikeyCredentialModel.createFromModel(model);
+	}
+
+	@Override
+	public CredentialTypeMetadata getCredentialTypeMetadata(CredentialTypeMetadataContext metadataContext) {
+		return CredentialTypeMetadata.builder()
+				.type(getType())
+				.category(CredentialTypeMetadata.Category.TWO_FACTOR)
+				.displayName("yubikey-display-name")
+				.helpText("yubikeyHelpText")
+				.createAction(YubikeyRequiredAction.PROVIDER_ID)
+				.removeable(true)
+				.build(session);
+	}
+
+	@Override
+	public String getType() {
+		return YubikeyCredentialModel.TYPE;
+	}
+
+	@Override
+	public Stream<String> getDisableableCredentialTypesStream(RealmModel realm, UserModel user) {
+		return Stream.empty();
+	}
+
+	@Override
+	public void disableCredentialType(RealmModel realm, UserModel user, String credentialType) {}
+}

--- a/yubikey-authenticator/src/main/java/netzbegruenung/keycloak/yubikey/YubikeyCredentialProviderFactory.java
+++ b/yubikey-authenticator/src/main/java/netzbegruenung/keycloak/yubikey/YubikeyCredentialProviderFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Netzbegruenung e.V.
+ * @author verdigado eG
+ */
+
+package netzbegruenung.keycloak.yubikey;
+
+import org.keycloak.credential.CredentialProvider;
+import org.keycloak.credential.CredentialProviderFactory;
+import org.keycloak.models.KeycloakSession;
+
+import netzbegruenung.keycloak.yubikey.credentials.YubikeyCredentialModel;
+
+public class YubikeyCredentialProviderFactory implements CredentialProviderFactory<YubikeyCredentialProvider> {
+
+	public static final String PROVIDER_ID = "yubikey";
+
+	@Override
+	public String getId() {
+		return PROVIDER_ID;
+	}
+
+	@Override
+	public CredentialProvider<YubikeyCredentialModel> create(KeycloakSession session) {
+		return new YubikeyCredentialProvider(session);
+	}
+}

--- a/yubikey-authenticator/src/main/java/netzbegruenung/keycloak/yubikey/YubikeyRequiredAction.java
+++ b/yubikey-authenticator/src/main/java/netzbegruenung/keycloak/yubikey/YubikeyRequiredAction.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Netzbegruenung e.V.
+ * @author verdigado eG
+ */
+
+package netzbegruenung.keycloak.yubikey;
+
+import jakarta.ws.rs.core.Response;
+import netzbegruenung.keycloak.yubikey.credentials.YubikeyCredentialModel;
+import org.jboss.logging.Logger;
+import org.keycloak.authentication.CredentialRegistrator;
+import org.keycloak.authentication.InitiatedActionSupport;
+import org.keycloak.authentication.RequiredActionContext;
+import org.keycloak.authentication.RequiredActionProvider;
+import org.keycloak.credential.CredentialModel;
+import org.keycloak.credential.CredentialProvider;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+import java.util.Map;
+
+public class YubikeyRequiredAction implements RequiredActionProvider, CredentialRegistrator {
+
+	public static final String PROVIDER_ID = "yubikey_config";
+
+	private static final Logger logger = Logger.getLogger(YubikeyRequiredAction.class);
+
+	@Override
+	public InitiatedActionSupport initiatedActionSupport() {
+		return InitiatedActionSupport.SUPPORTED;
+	}
+
+	@Override
+	public void evaluateTriggers(RequiredActionContext context) {
+		// no-op: we do not enforce 2FA enrollment
+	}
+
+	/**
+	 * Looks up the Yubico admin config by the fixed config alias "yubikey-2fa".
+	 * The Required Action runs outside the authenticator execution and has no
+	 * direct handle to the authenticator's config, so the admin must name the
+	 * execution's config alias exactly "yubikey-2fa".
+	 */
+	static Map<String, String> yubikeyConfig(RealmModel realm) {
+		AuthenticatorConfigModel config = realm.getAuthenticatorConfigByAlias("yubikey-2fa");
+		if (config == null) {
+			logger.error("Failed to load YubiKey config, no config alias yubikey-2fa found");
+			return Map.of();
+		}
+		return config.getConfig();
+	}
+
+	@Override
+	public void requiredActionChallenge(RequiredActionContext context) {
+		context.challenge(context.form().createForm("yubikey-enroll.ftl"));
+	}
+
+	@Override
+	public void processAction(RequiredActionContext context) {
+		String otp = context.getHttpRequest().getDecodedFormParameters().getFirst("otp");
+
+		Map<String, String> config = yubikeyConfig(context.getRealm());
+		String clientId = config.get("clientId");
+		String secretKey = config.get("secretKey");
+		String validationUrl = config.getOrDefault("validationUrl", "https://api.yubico.com/wsapi/2.0/verify");
+
+		String publicId = YubicoVerifier.yubikeyPublicId(otp);
+		if (otp == null || otp.length() != 44 || publicId == null) {
+			handleInvalid(context, "yubikeyEnrollInvalid");
+			return;
+		}
+
+		if (clientId == null || secretKey == null) {
+			logger.error("Cannot verify YubiKey OTP: missing clientId/secretKey in config alias yubikey-2fa");
+			handleInvalid(context, "yubikeyEnrollInvalid");
+			return;
+		}
+
+		YubicoVerifier verifier = new YubicoVerifier(validationUrl, clientId, secretKey);
+		YubicoVerifier.Result result = verifier.verify(otp);
+		if (result != YubicoVerifier.Result.OK) {
+			handleInvalid(context, "yubikeyEnrollInvalid");
+			return;
+		}
+
+		// guard against duplicate enrollment of the same public id for this user
+		boolean alreadyEnrolled = context.getUser().credentialManager()
+			.getStoredCredentialsByTypeStream(YubikeyCredentialModel.TYPE)
+			.map(m -> YubikeyCredentialModel.createFromModel(m).getYubikeyData().getPublicId())
+			.anyMatch(publicId::equals);
+		if (alreadyEnrolled) {
+			handleInvalid(context, "yubikeyEnrollDuplicate");
+			return;
+		}
+
+		YubikeyCredentialProvider cp = (YubikeyCredentialProvider)
+			context.getSession().getProvider(CredentialProvider.class, YubikeyCredentialProviderFactory.PROVIDER_ID);
+		cp.createCredential(context.getRealm(), context.getUser(),
+			YubikeyCredentialModel.createYubikey(publicId, "YubiKey " + publicId));
+
+		context.success();
+	}
+
+	private void handleInvalid(RequiredActionContext context, String errorMessage) {
+		Response challenge = context.form()
+			.setError(errorMessage)
+			.createForm("yubikey-enroll.ftl");
+		context.challenge(challenge);
+	}
+
+	@Override
+	public void close() {}
+
+	@Override
+	public String getCredentialType(KeycloakSession keycloakSession, AuthenticationSessionModel authenticationSessionModel) {
+		return YubikeyCredentialModel.TYPE;
+	}
+}

--- a/yubikey-authenticator/src/main/java/netzbegruenung/keycloak/yubikey/YubikeyRequiredActionFactory.java
+++ b/yubikey-authenticator/src/main/java/netzbegruenung/keycloak/yubikey/YubikeyRequiredActionFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Netzbegruenung e.V.
+ * @author verdigado eG
+ */
+
+package netzbegruenung.keycloak.yubikey;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.RequiredActionFactory;
+import org.keycloak.authentication.RequiredActionProvider;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+public class YubikeyRequiredActionFactory implements RequiredActionFactory {
+
+	private static final YubikeyRequiredAction SINGLETON = new YubikeyRequiredAction();
+
+	@Override
+	public RequiredActionProvider create(KeycloakSession session) {
+		return SINGLETON;
+	}
+
+	@Override
+	public String getId() {
+		return YubikeyRequiredAction.PROVIDER_ID;
+	}
+
+	@Override
+	public String getDisplayText() {
+		return "Set up YubiKey";
+	}
+
+	@Override
+	public void init(Config.Scope config) {
+	}
+
+	@Override
+	public void postInit(KeycloakSessionFactory factory) {
+	}
+
+	@Override
+	public void close() {
+	}
+
+}

--- a/yubikey-authenticator/src/main/java/netzbegruenung/keycloak/yubikey/credentials/YubikeyCredentialData.java
+++ b/yubikey-authenticator/src/main/java/netzbegruenung/keycloak/yubikey/credentials/YubikeyCredentialData.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Netzbegruenung e.V.
+ * @author verdigado eG
+ */
+
+package netzbegruenung.keycloak.yubikey.credentials;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class YubikeyCredentialData {
+
+	private final String publicId;
+
+	public YubikeyCredentialData(@JsonProperty("public_id") String publicId) {
+		this.publicId = publicId;
+	}
+
+	public String getPublicId() {
+		return publicId;
+	}
+}

--- a/yubikey-authenticator/src/main/java/netzbegruenung/keycloak/yubikey/credentials/YubikeyCredentialModel.java
+++ b/yubikey-authenticator/src/main/java/netzbegruenung/keycloak/yubikey/credentials/YubikeyCredentialModel.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Netzbegruenung e.V.
+ * @author verdigado eG
+ */
+
+package netzbegruenung.keycloak.yubikey.credentials;
+
+import org.keycloak.common.util.Time;
+import org.keycloak.credential.CredentialModel;
+import org.keycloak.util.JsonSerialization;
+
+import java.io.IOException;
+
+public class YubikeyCredentialModel extends CredentialModel {
+	public static final String TYPE = "yubikey";
+
+	private final YubikeyCredentialData yubikeyData;
+
+	private YubikeyCredentialModel(YubikeyCredentialData yubikeyData) {
+		this.yubikeyData = yubikeyData;
+	}
+
+	public static YubikeyCredentialModel createFromModel(CredentialModel credentialModel) {
+		try {
+			YubikeyCredentialData credentialData = JsonSerialization.readValue(credentialModel.getCredentialData(), YubikeyCredentialData.class);
+
+			YubikeyCredentialModel yubikeyCredentialModel = new YubikeyCredentialModel(credentialData);
+			yubikeyCredentialModel.setUserLabel(credentialModel.getUserLabel());
+			yubikeyCredentialModel.setCreatedDate(credentialModel.getCreatedDate());
+			yubikeyCredentialModel.setType(TYPE);
+			yubikeyCredentialModel.setId(credentialModel.getId());
+			yubikeyCredentialModel.setCredentialData(credentialModel.getCredentialData());
+			return yubikeyCredentialModel;
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public static YubikeyCredentialModel createYubikey(String publicId, String label) {
+		YubikeyCredentialModel credentialModel = new YubikeyCredentialModel(new YubikeyCredentialData(publicId));
+		credentialModel.fillCredentialModelFields(label);
+		return credentialModel;
+	}
+
+	public YubikeyCredentialData getYubikeyData() {
+		return yubikeyData;
+	}
+
+	private void fillCredentialModelFields(String label) {
+		try {
+			setCredentialData(JsonSerialization.writeValueAsString(yubikeyData));
+			setType(TYPE);
+			setCreatedDate(Time.currentTimeMillis());
+			setUserLabel(label);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/yubikey-authenticator/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/yubikey-authenticator/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -1,0 +1,1 @@
+netzbegruenung.keycloak.yubikey.YubikeyAuthenticatorFactory

--- a/yubikey-authenticator/src/main/resources/META-INF/services/org.keycloak.authentication.RequiredActionFactory
+++ b/yubikey-authenticator/src/main/resources/META-INF/services/org.keycloak.authentication.RequiredActionFactory
@@ -1,0 +1,1 @@
+netzbegruenung.keycloak.yubikey.YubikeyRequiredActionFactory

--- a/yubikey-authenticator/src/main/resources/META-INF/services/org.keycloak.credential.CredentialProviderFactory
+++ b/yubikey-authenticator/src/main/resources/META-INF/services/org.keycloak.credential.CredentialProviderFactory
@@ -1,0 +1,1 @@
+netzbegruenung.keycloak.yubikey.YubikeyCredentialProviderFactory

--- a/yubikey-authenticator/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/yubikey-authenticator/src/main/resources/theme-resources/messages/messages_en.properties
@@ -1,0 +1,14 @@
+yubikey-display-name=YubiKey
+yubikeyHelpText=Use a YubiKey (OTP) as your second factor.
+
+yubikeyLoginTitle=YubiKey
+yubikeyLoginLabel=YubiKey OTP
+yubikeyLoginInstruction=Touch your YubiKey to enter the one-time password.
+yubikeyInvalid=That does not look like a valid YubiKey OTP. Touch your key again.
+yubikeyNotEnrolled=This YubiKey is not registered to your account.
+
+yubikeyEnrollTitle=Register your YubiKey
+yubikeyEnrollLabel=YubiKey OTP
+yubikeyEnrollInstruction=Touch your YubiKey to register it as a second factor.
+yubikeyEnrollInvalid=Could not verify that YubiKey. Please try again.
+yubikeyEnrollDuplicate=This YubiKey is already registered to your account.

--- a/yubikey-authenticator/src/main/resources/theme-resources/templates/yubikey-enroll.ftl
+++ b/yubikey-authenticator/src/main/resources/theme-resources/templates/yubikey-enroll.ftl
@@ -1,0 +1,39 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayInfo=true; section>
+	<#if section = "header">
+		${msg("yubikeyEnrollTitle")}
+	<#elseif section = "form">
+		<form id="kc-yubikey-enroll-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
+			<div class="${properties.kcFormGroupClass!}">
+				<div class="${properties.kcLabelWrapperClass!}">
+					<label for="otp" class="${properties.kcLabelClass!}">${msg("yubikeyEnrollLabel")}</label>
+				</div>
+				<div class="${properties.kcInputWrapperClass!}">
+					<input type="text" id="otp" name="otp" class="${properties.kcInputClass!}"
+						   autocomplete="off" autofocus />
+				</div>
+			</div>
+			<div class="pf-v5-c-form__group pf-m-action">
+				<div class="pf-v5-c-form__actions">
+					<#if isAppInitiatedAction??>
+						<input type="submit"
+							class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}"
+							value="${msg("doSubmit")}"
+						/>
+						<button type="submit"
+							class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonLargeClass!} ${properties.kcButtonLargeClass!}"
+							name="cancel-aia" value="true">${msg("doCancel")}
+						</button>
+					<#else>
+						<input type="submit"
+							class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
+							value="${msg("doSubmit")}"
+						/>
+					</#if>
+				</div>
+			</div>
+		</form>
+	<#elseif section = "info">
+		${msg("yubikeyEnrollInstruction")}
+	</#if>
+</@layout.registrationLayout>

--- a/yubikey-authenticator/src/main/resources/theme-resources/templates/yubikey-login.ftl
+++ b/yubikey-authenticator/src/main/resources/theme-resources/templates/yubikey-login.ftl
@@ -1,0 +1,24 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayInfo=true; section>
+	<#if section = "header">
+		${msg("yubikeyLoginTitle")}
+	<#elseif section = "form">
+		<form id="kc-yubikey-login-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
+			<div class="${properties.kcFormGroupClass!}">
+				<div class="${properties.kcLabelWrapperClass!}">
+					<label for="otp" class="${properties.kcLabelClass!}">${msg("yubikeyLoginLabel")}</label>
+				</div>
+				<div class="${properties.kcInputWrapperClass!}">
+					<input type="text" id="otp" name="otp" class="${properties.kcInputClass!}"
+						   autocomplete="off" autofocus />
+				</div>
+			</div>
+			<div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
+				<input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
+					   type="submit" value="${msg("doSubmit")}"/>
+			</div>
+		</form>
+	<#elseif section = "info">
+		${msg("yubikeyLoginInstruction")}
+	</#if>
+</@layout.registrationLayout>

--- a/yubikey-authenticator/src/test/java/netzbegruenung/keycloak/yubikey/YubicoVerifierTest.java
+++ b/yubikey-authenticator/src/test/java/netzbegruenung/keycloak/yubikey/YubicoVerifierTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Netzbegruenung e.V.
+ * @author verdigado eG
+ */
+
+package netzbegruenung.keycloak.yubikey;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class YubicoVerifierTest {
+
+	/**
+	 * Official Yubico test vector for the HMAC-SHA1 request/response signature.
+	 * https://developers.yubico.com/OTP/Specifications/OTP_validation_protocol.html
+	 */
+	@Test
+	void testOfficialSignatureVector() {
+		String secretKeyBase64 = "mG5be6ZJU1qBGz24yPh/ESM3UdU=";
+		byte[] apiKeyRaw = Base64.getDecoder().decode(secretKeyBase64);
+
+		SortedMap<String, String> params = new TreeMap<>();
+		params.put("id", "1");
+		params.put("nonce", "jrFwbaYFhn0HoxZIsd9LQ6w2ceU");
+		params.put("otp", "vvungrrdhvtklknvrtvuvbbkeidikkvgglrvdgrfcdft");
+
+		String signature = YubicoVerifier.yubicoSign(apiKeyRaw, params);
+
+		assertEquals("+ja8S3IjbX593/LAgTBixwPNGX4=", signature);
+	}
+
+	@Test
+	void testStringToSignFormat() {
+		SortedMap<String, String> params = new TreeMap<>();
+		params.put("otp", "vvungrrdhvtklknvrtvuvbbkeidikkvgglrvdgrfcdft");
+		params.put("id", "1");
+		params.put("nonce", "jrFwbaYFhn0HoxZIsd9LQ6w2ceU");
+
+		// TreeMap sorts lexicographically by key regardless of insertion order
+		String expectedOrder = "id=1&nonce=jrFwbaYFhn0HoxZIsd9LQ6w2ceU&otp=vvungrrdhvtklknvrtvuvbbkeidikkvgglrvdgrfcdft";
+		StringBuilder actual = new StringBuilder();
+		params.forEach((k, v) -> {
+			if (actual.length() > 0) actual.append("&");
+			actual.append(k).append("=").append(v);
+		});
+
+		assertEquals(expectedOrder, actual.toString());
+	}
+
+	@Test
+	void testYubikeyPublicId() {
+		String otp = "vvungrrdhvtklknvrtvuvbbkeidikkvgglrvdgrfcdft";
+		assertEquals("vvungrrdhvtk", YubicoVerifier.yubikeyPublicId(otp));
+	}
+
+	@Test
+	void testYubikeyPublicIdTooShort() {
+		assertNull(YubicoVerifier.yubikeyPublicId("short"));
+		assertNull(YubicoVerifier.yubikeyPublicId(null));
+	}
+
+	@Test
+	void testParseResponse() {
+		String body = "h=abc123=\r\n"
+			+ "t=2024-01-01T00:00:00Z0000\r\n"
+			+ "otp=vvungrrdhvtklknvrtvuvbbkeidikkvgglrvdgrfcdft\r\n"
+			+ "nonce=jrFwbaYFhn0HoxZIsd9LQ6w2ceU\r\n"
+			+ "sl=100\r\n"
+			+ "status=OK\r\n";
+
+		SortedMap<String, String> parsed = YubicoVerifier.parseResponse(body);
+
+		assertEquals("abc123=", parsed.get("h"));
+		assertEquals("OK", parsed.get("status"));
+		assertEquals("jrFwbaYFhn0HoxZIsd9LQ6w2ceU", parsed.get("nonce"));
+		assertEquals("vvungrrdhvtklknvrtvuvbbkeidikkvgglrvdgrfcdft", parsed.get("otp"));
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a Keycloak authenticator/required-action module (`yubikey-authenticator`) that lets users enroll and log in with a physical YubiKey using Yubico's OTP validation protocol (v2.0), following the same module structure as the existing `sms-authenticator` / `app-authenticator`.
- Registers the new module in the root `pom.xml`.

## Test plan
- [ ] `mvn clean install` from repo root builds successfully
- [ ] Unit tests pass (`YubicoVerifierTest`, incl. official Yubico HMAC-SHA1 test vector)
- [ ] Manual: enroll a YubiKey via account console, log in with 2FA against `api.yubico.com`