### PR TITLE
Add trusted device authenticator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
           cp email-authenticator/target/*.jar staging
           cp app-authenticator/target/*.jar staging
           cp enforce-mfa/target/*.jar staging
+          cp trusted-device-authenticator/target/*.jar staging
       - name: Create hash files
         run: |
           for jar in *.jar

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains the source code for a collection of Keycloak MFA plugin
 * [Email authenticator](email-authenticator/README.md): Provides Email OTP as authentication step. Uses the SMTP server configured in the realm. (production ready)
 * [Enforce MFA](enforce-mfa/README.md): Force users to configure a second factor after logging in. (beta)
 * [Native App MFA integration](app-authenticator/README.md): connect a mobile app to Keycloak which receives a notification about a pending login process and allows the user to allow/block the login request. (work in progress)
+* [Trusted Device authenticator](trusted-device-authenticator/README.md): remember a device after a successful 2FA login and skip the second factor on it for a configurable period.
 
 The different plugins are documented in the submodules README. If you need support for deployment or adjustments, please contact [support@verdigado.com](mailto:support@verdigado.com).
 

--- a/mfa-dev-runner/pom.xml
+++ b/mfa-dev-runner/pom.xml
@@ -31,6 +31,11 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>netzbegruenung</groupId>
+			<artifactId>trusted-device-authenticator</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-quarkus-server</artifactId>
 			<version>${keycloak.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
 		<module>email-authenticator</module>
         <module>app-authenticator</module>
 		<module>enforce-mfa</module>
+		<module>trusted-device-authenticator</module>
 		<module>mfa-dev-runner</module>
 	</modules>
 

--- a/trusted-device-authenticator/README.md
+++ b/trusted-device-authenticator/README.md
@@ -13,7 +13,6 @@ This is an independent reimplementation of the ideas from upstream Keycloak pull
 1. Run the `build` command and restart Keycloak:
    ```shell
    /path/to/keycloak/bin/kc.sh build [your-additional-flags]
-   systemctl restart keycloak.service
    ```
 
 # Setup

--- a/trusted-device-authenticator/README.md
+++ b/trusted-device-authenticator/README.md
@@ -1,0 +1,35 @@
+# Keycloak Trusted Device Authenticator
+
+Keycloak Authentication Provider implementation that lets a user mark their browser as a trusted device after a successful second-factor login, so subsequent logins from that same browser can skip the second factor until the trust expires.
+
+This is an independent reimplementation of the ideas from upstream Keycloak pull request [keycloak/keycloak#48138](https://github.com/keycloak/keycloak/pull/48138), rebuilt on public Keycloak SPI extension points so it can ship as a regular provider jar instead of requiring a patched Keycloak core.
+
+# Installing
+1. Go to https://github.com/netzbegruenung/keycloak-mfa-plugins/releases and download the latest `netzbegruenung.trusted-device-authenticator-*.jar`.
+1. Copy the jar into the `providers` directory of your Keycloak:
+   ```shell
+   cp netzbegruenung.trusted-device-authenticator-*.jar /path/to/keycloak/providers
+   ```
+1. Run the `build` command and restart Keycloak:
+   ```shell
+   /path/to/keycloak/bin/kc.sh build [your-additional-flags]
+   systemctl restart keycloak.service
+   ```
+
+# Setup
+1. Go to `/admin/master/console/#/YOUR-REALM/authentication/required-actions` and enable the required action **Manage Trusted Device**.
+1. Navigate to your Authentication flow configuration and duplicate the flow you want to use (e.g. `browser`), since built-in flows are read-only.
+1. Inside the 2FA part of the flow, add the two steps so that the trusted-device check runs as an alternative to your existing second factor:
+   1. Add `Trusted Device` and set it to `Alternative`.
+   1. Add a sub-flow (also `Alternative`) that contains your existing second-factor step(s) (e.g. `OTP Form`) set to `Required`, followed by `Trusted Device Register` set to `Required`.
+1. Click the **Actions** menu (three dots) next to the `Manage Trusted Device` required action and select **Config** to set:
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| Trust duration (days) | Number of days the device stays trusted before the user is asked again. | `7` |
+
+# Usage
+After a user completes their normal second factor, they're asked whether to trust the current device. If they accept, a signed cookie and a matching `netzbegruenung-trusted-device` credential are stored for the user; as long as both are present and unexpired, the `Trusted Device` step succeeds and the second-factor sub-flow is skipped on that browser. The trusted device also shows up in the account console (`/realms/realm/account/#/account-security/signing-in`) and can be revoked there like any other credential.
+
+# License
+Apache License 2.0

--- a/trusted-device-authenticator/pom.xml
+++ b/trusted-device-authenticator/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>trusted-device-authenticator</artifactId>
+
+    <parent>
+        <groupId>netzbegruenung</groupId>
+        <artifactId>keycloak-mfa-tools</artifactId>
+        <version>26.6.5</version>
+    </parent>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.keycloak.testframework</groupId>
+                <artifactId>keycloak-test-framework-bom</artifactId>
+                <version>${keycloak.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-core</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-server-spi</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-server-spi-private</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-services</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.logging</groupId>
+			<artifactId>jboss-logging</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.ws.rs</groupId>
+			<artifactId>jakarta.ws.rs-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak.testframework</groupId>
+			<artifactId>keycloak-test-framework-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak.testframework</groupId>
+			<artifactId>keycloak-test-framework-junit5-config</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak.testframework</groupId>
+			<artifactId>keycloak-test-framework-oauth</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak.testframework</groupId>
+			<artifactId>keycloak-test-framework-ui</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak.testframework</groupId>
+			<artifactId>keycloak-test-framework-remote</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak.tests</groupId>
+			<artifactId>keycloak-tests-utils-shared</artifactId>
+			<version>${keycloak.version}</version>
+			<scope>test</scope>
+		</dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.groupId}.${project.artifactId}-v${project.version}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceAuthenticator.java
+++ b/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceAuthenticator.java
@@ -1,10 +1,8 @@
 package netzbegruenung.keycloak.trusteddevice;
 
-import netzbegruenung.keycloak.trusteddevice.credentials.TrustedDeviceCredentialModel;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.Authenticator;
 import org.keycloak.authentication.CredentialValidator;
-import org.keycloak.common.util.Time;
 import org.keycloak.credential.CredentialProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -14,8 +12,7 @@ public class TrustedDeviceAuthenticator implements Authenticator, CredentialVali
 
     @Override
     public void authenticate(AuthenticationFlowContext context) {
-        TrustedDeviceCredentialModel credential = validateCookie(context.getSession(), context.getUser());
-        if (credential != null) {
+        if (getCredentialProvider(context.getSession()).isTrustedDevice(context.getSession(), context.getRealm(), context.getUser())) {
             context.success();
         } else {
             context.getAuthenticationSession().addRequiredAction(TrustedDeviceRegisterRequiredAction.PROVIDER_ID);
@@ -25,34 +22,6 @@ public class TrustedDeviceAuthenticator implements Authenticator, CredentialVali
 
     @Override
     public void action(AuthenticationFlowContext context) {
-    }
-
-    public TrustedDeviceCredentialModel validateCookie(KeycloakSession session, UserModel user) {
-        TrustedDeviceToken deviceToken = getToken(session);
-        if (deviceToken == null) {
-            return null;
-        }
-
-        return user.credentialManager().getStoredCredentialsByTypeStream(TrustedDeviceCredentialModel.TYPE)
-                .map(TrustedDeviceCredentialModel::createFromCredentialModel)
-                .filter(c -> c.getDeviceId().equals(deviceToken.getDeviceId()))
-                .filter(c -> c.getExpireTime() > Time.currentTime())
-                .findFirst()
-                .orElse(null);
-    }
-
-    public TrustedDeviceToken getToken(KeycloakSession session) {
-        String tokenString = TrustedDeviceCookie.read(session);
-        if (tokenString == null) {
-            return null;
-        }
-
-        TrustedDeviceToken decoded = session.tokens().decode(tokenString, TrustedDeviceToken.class);
-        if (decoded != null && decoded.getExp() > Time.currentTime()) {
-            return decoded;
-        }
-
-        return null;
     }
 
     @Override

--- a/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceAuthenticator.java
+++ b/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceAuthenticator.java
@@ -1,0 +1,80 @@
+package netzbegruenung.keycloak.trusteddevice;
+
+import netzbegruenung.keycloak.trusteddevice.credentials.TrustedDeviceCredentialModel;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.CredentialValidator;
+import org.keycloak.common.util.Time;
+import org.keycloak.credential.CredentialProvider;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+
+public class TrustedDeviceAuthenticator implements Authenticator, CredentialValidator<TrustedDeviceCredentialProvider> {
+
+    @Override
+    public void authenticate(AuthenticationFlowContext context) {
+        TrustedDeviceCredentialModel credential = validateCookie(context.getSession(), context.getUser());
+        if (credential != null) {
+            context.success();
+        } else {
+            context.getAuthenticationSession().addRequiredAction(TrustedDeviceRegisterRequiredAction.PROVIDER_ID);
+            context.attempted();
+        }
+    }
+
+    @Override
+    public void action(AuthenticationFlowContext context) {
+    }
+
+    public TrustedDeviceCredentialModel validateCookie(KeycloakSession session, UserModel user) {
+        TrustedDeviceToken deviceToken = getToken(session);
+        if (deviceToken == null) {
+            return null;
+        }
+
+        return user.credentialManager().getStoredCredentialsByTypeStream(TrustedDeviceCredentialModel.TYPE)
+                .map(TrustedDeviceCredentialModel::createFromCredentialModel)
+                .filter(c -> c.getDeviceId().equals(deviceToken.getDeviceId()))
+                .filter(c -> c.getExpireTime() > Time.currentTime())
+                .findFirst()
+                .orElse(null);
+    }
+
+    public TrustedDeviceToken getToken(KeycloakSession session) {
+        String tokenString = TrustedDeviceCookie.read(session);
+        if (tokenString == null) {
+            return null;
+        }
+
+        TrustedDeviceToken decoded = session.tokens().decode(tokenString, TrustedDeviceToken.class);
+        if (decoded != null && decoded.getExp() > Time.currentTime()) {
+            return decoded;
+        }
+
+        return null;
+    }
+
+    @Override
+    public boolean requiresUser() {
+        return true;
+    }
+
+    @Override
+    public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+        return user.credentialManager().isConfiguredFor(getCredentialProvider(session).getType());
+    }
+
+    @Override
+    public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public TrustedDeviceCredentialProvider getCredentialProvider(KeycloakSession session) {
+        return (TrustedDeviceCredentialProvider) session.getProvider(CredentialProvider.class, TrustedDeviceCredentialProviderFactory.PROVIDER_ID);
+    }
+}

--- a/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceAuthenticatorFactory.java
+++ b/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceAuthenticatorFactory.java
@@ -1,0 +1,81 @@
+package netzbegruenung.keycloak.trusteddevice;
+
+import java.util.List;
+
+import netzbegruenung.keycloak.trusteddevice.credentials.TrustedDeviceCredentialModel;
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+public class TrustedDeviceAuthenticatorFactory implements AuthenticatorFactory {
+
+    public static final String PROVIDER_ID = "nb-trusted-device";
+    private static final TrustedDeviceAuthenticator SINGLETON = new TrustedDeviceAuthenticator();
+
+    private static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
+            AuthenticationExecutionModel.Requirement.REQUIRED,
+            AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+            AuthenticationExecutionModel.Requirement.DISABLED
+    };
+
+    @Override
+    public String getDisplayType() {
+        return "Trusted Device";
+    }
+
+    @Override
+    public String getReferenceCategory() {
+        return TrustedDeviceCredentialModel.TYPE;
+    }
+
+    @Override
+    public boolean isConfigurable() {
+        return false;
+    }
+
+    @Override
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return REQUIREMENT_CHOICES;
+    }
+
+    @Override
+    public boolean isUserSetupAllowed() {
+        return true;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Validates the trusted-device cookie set by the Trusted Device Register step.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return List.of();
+    }
+
+    @Override
+    public Authenticator create(KeycloakSession session) {
+        return SINGLETON;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+}

--- a/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceCookie.java
+++ b/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceCookie.java
@@ -1,0 +1,40 @@
+package netzbegruenung.keycloak.trusteddevice;
+
+import jakarta.ws.rs.core.Cookie;
+import jakarta.ws.rs.core.NewCookie;
+import org.keycloak.models.KeycloakSession;
+
+/**
+ * Reads and writes the trusted-device cookie directly through the public HttpRequest/HttpResponse SPI.
+ * The core CookieProvider/CookieType abstraction can't be used here since minting a new CookieType
+ * constant requires a private builder method that's only callable from Keycloak core itself.
+ */
+public class TrustedDeviceCookie {
+
+    public static final String NAME = "TRUSTED_DEVICE";
+
+    private TrustedDeviceCookie() {
+    }
+
+    public static String read(KeycloakSession session) {
+        Cookie cookie = session.getContext().getHttpRequest().getHttpHeaders().getCookies().get(NAME);
+        return cookie == null ? null : cookie.getValue();
+    }
+
+    public static void write(KeycloakSession session, String encodedToken, int maxAgeSeconds) {
+        // SameSite=None is only honoured by browsers together with Secure, which in turn requires HTTPS -
+        // fall back to Lax without Secure on plain HTTP (e.g. a non-TLS-terminated dev/test server).
+        boolean https = "https".equalsIgnoreCase(session.getContext().getUri().getBaseUri().getScheme());
+        NewCookie.Builder builder = new NewCookie.Builder(NAME)
+                .value(encodedToken)
+                .path("/")
+                .maxAge(maxAgeSeconds)
+                .httpOnly(true);
+        if (https) {
+            builder.secure(true).sameSite(NewCookie.SameSite.NONE);
+        } else {
+            builder.sameSite(NewCookie.SameSite.LAX);
+        }
+        session.getContext().getHttpResponse().setCookieIfAbsent(builder.build());
+    }
+}

--- a/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceCredentialProvider.java
+++ b/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceCredentialProvider.java
@@ -88,9 +88,32 @@ public class TrustedDeviceCredentialProvider implements CredentialProvider<Trust
         }
 
         CredentialModel credential = user.credentialManager().getStoredCredentialById(credentialInput.getCredentialId());
+        if (credential == null) {
+            return false;
+        }
         TrustedDeviceCredentialModel trustedDeviceCredentialModel = getCredentialFromModel(credential);
         return trustedDeviceCredentialModel != null
                 && challengeResponse.equals(trustedDeviceCredentialModel.getDeviceId())
                 && trustedDeviceCredentialModel.getExpireTime() > Time.currentTime();
+    }
+
+    /**
+     * Reads and validates the trusted-device cookie in one step: decodes the token, checks its
+     * expiry, then validates it against the user's stored credential via isValid() using the
+     * credential id already embedded in the token.
+     */
+    public boolean isTrustedDevice(KeycloakSession session, RealmModel realm, UserModel user) {
+        String tokenString = TrustedDeviceCookie.read(session);
+        if (tokenString == null) {
+            return false;
+        }
+
+        TrustedDeviceToken token = session.tokens().decode(tokenString, TrustedDeviceToken.class);
+        if (token == null || token.getExp() <= Time.currentTime()) {
+            return false;
+        }
+
+        UserCredentialModel input = new UserCredentialModel(token.getId(), TrustedDeviceCredentialModel.TYPE, token.getDeviceId());
+        return isValid(realm, user, input);
     }
 }

--- a/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceCredentialProvider.java
+++ b/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceCredentialProvider.java
@@ -1,0 +1,96 @@
+package netzbegruenung.keycloak.trusteddevice;
+
+import netzbegruenung.keycloak.trusteddevice.credentials.TrustedDeviceCredentialModel;
+import org.jboss.logging.Logger;
+import org.keycloak.common.util.ObjectUtil;
+import org.keycloak.common.util.Time;
+import org.keycloak.credential.CredentialInput;
+import org.keycloak.credential.CredentialInputValidator;
+import org.keycloak.credential.CredentialModel;
+import org.keycloak.credential.CredentialProvider;
+import org.keycloak.credential.CredentialTypeMetadata;
+import org.keycloak.credential.CredentialTypeMetadataContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserCredentialModel;
+import org.keycloak.models.UserModel;
+
+public class TrustedDeviceCredentialProvider implements CredentialProvider<TrustedDeviceCredentialModel>, CredentialInputValidator {
+
+    private static final Logger logger = Logger.getLogger(TrustedDeviceCredentialProvider.class);
+
+    private final KeycloakSession session;
+
+    public TrustedDeviceCredentialProvider(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Override
+    public String getType() {
+        return TrustedDeviceCredentialModel.TYPE;
+    }
+
+    @Override
+    public CredentialModel createCredential(RealmModel realm, UserModel user, TrustedDeviceCredentialModel credentialModel) {
+        if (credentialModel.getCreatedDate() == null) {
+            credentialModel.setCreatedDate(Time.currentTimeMillis());
+        }
+
+        return user.credentialManager().createStoredCredential(credentialModel);
+    }
+
+    @Override
+    public boolean deleteCredential(RealmModel realm, UserModel user, String credentialId) {
+        return user.credentialManager().removeStoredCredentialById(credentialId);
+    }
+
+    @Override
+    public TrustedDeviceCredentialModel getCredentialFromModel(CredentialModel model) {
+        return TrustedDeviceCredentialModel.createFromCredentialModel(model);
+    }
+
+    @Override
+    public CredentialTypeMetadata getCredentialTypeMetadata(CredentialTypeMetadataContext metadataContext) {
+        return CredentialTypeMetadata.builder()
+                .type(getType())
+                .category(CredentialTypeMetadata.Category.TWO_FACTOR)
+                .displayName("trustedDeviceDisplayName")
+                .helpText("trustedDeviceHelpText")
+                .iconCssClass("kcAuthenticatorWebAuthnClass")
+                .removeable(true)
+                .build(session);
+    }
+
+    @Override
+    public boolean supportsCredentialType(String type) {
+        return type.equals(getType());
+    }
+
+    @Override
+    public boolean isConfiguredFor(RealmModel realm, UserModel user, String credentialType) {
+        if (!supportsCredentialType(credentialType)) return false;
+        return user.credentialManager().getStoredCredentialsByTypeStream(credentialType).findAny().isPresent();
+    }
+
+    @Override
+    public boolean isValid(RealmModel realm, UserModel user, CredentialInput credentialInput) {
+        if (!(credentialInput instanceof UserCredentialModel)) {
+            logger.debug("Expected instance of UserCredentialModel for CredentialInput");
+            return false;
+        }
+        String challengeResponse = credentialInput.getChallengeResponse();
+        if (challengeResponse == null) {
+            return false;
+        }
+        if (ObjectUtil.isBlank(credentialInput.getCredentialId())) {
+            logger.debugf("CredentialId is null when validating credential of user %s", user.getUsername());
+            return false;
+        }
+
+        CredentialModel credential = user.credentialManager().getStoredCredentialById(credentialInput.getCredentialId());
+        TrustedDeviceCredentialModel trustedDeviceCredentialModel = getCredentialFromModel(credential);
+        return trustedDeviceCredentialModel != null
+                && challengeResponse.equals(trustedDeviceCredentialModel.getDeviceId())
+                && trustedDeviceCredentialModel.getExpireTime() > Time.currentTime();
+    }
+}

--- a/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceCredentialProviderFactory.java
+++ b/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceCredentialProviderFactory.java
@@ -1,0 +1,21 @@
+package netzbegruenung.keycloak.trusteddevice;
+
+import netzbegruenung.keycloak.trusteddevice.credentials.TrustedDeviceCredentialModel;
+import org.keycloak.credential.CredentialProvider;
+import org.keycloak.credential.CredentialProviderFactory;
+import org.keycloak.models.KeycloakSession;
+
+public class TrustedDeviceCredentialProviderFactory implements CredentialProviderFactory<TrustedDeviceCredentialProvider> {
+
+    public static final String PROVIDER_ID = "nb-trusted-device";
+
+    @Override
+    public CredentialProvider<TrustedDeviceCredentialModel> create(KeycloakSession session) {
+        return new TrustedDeviceCredentialProvider(session);
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+}

--- a/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceRegisterAuthenticator.java
+++ b/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceRegisterAuthenticator.java
@@ -1,0 +1,57 @@
+package netzbegruenung.keycloak.trusteddevice;
+
+import netzbegruenung.keycloak.trusteddevice.credentials.TrustedDeviceCredentialModel;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.common.util.Time;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+
+public class TrustedDeviceRegisterAuthenticator implements Authenticator {
+
+    @Override
+    public void authenticate(AuthenticationFlowContext context) {
+        String tokenString = TrustedDeviceCookie.read(context.getSession());
+        TrustedDeviceToken deviceToken = tokenString == null
+                ? null
+                : context.getSession().tokens().decode(tokenString, TrustedDeviceToken.class);
+
+        if (deviceToken != null && deviceToken.getExp() > Time.currentTime()) {
+            boolean tokenIsValid = context.getUser().credentialManager()
+                    .getStoredCredentialsByTypeStream(TrustedDeviceCredentialModel.TYPE)
+                    .map(TrustedDeviceCredentialModel::createFromCredentialModel)
+                    .anyMatch(c -> c.getDeviceId().equals(deviceToken.getDeviceId()) && c.getExpireTime() > Time.currentTime());
+            if (tokenIsValid) {
+                context.success();
+                return;
+            }
+        }
+
+        context.getUser().addRequiredAction(TrustedDeviceRegisterRequiredAction.PROVIDER_ID);
+        context.success();
+    }
+
+    @Override
+    public void action(AuthenticationFlowContext context) {
+    }
+
+    @Override
+    public boolean requiresUser() {
+        return true;
+    }
+
+    @Override
+    public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+        return true;
+    }
+
+    @Override
+    public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+        user.addRequiredAction(TrustedDeviceRegisterRequiredAction.PROVIDER_ID);
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceRegisterAuthenticator.java
+++ b/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceRegisterAuthenticator.java
@@ -1,9 +1,8 @@
 package netzbegruenung.keycloak.trusteddevice;
 
-import netzbegruenung.keycloak.trusteddevice.credentials.TrustedDeviceCredentialModel;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.Authenticator;
-import org.keycloak.common.util.Time;
+import org.keycloak.credential.CredentialProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
@@ -12,20 +11,11 @@ public class TrustedDeviceRegisterAuthenticator implements Authenticator {
 
     @Override
     public void authenticate(AuthenticationFlowContext context) {
-        String tokenString = TrustedDeviceCookie.read(context.getSession());
-        TrustedDeviceToken deviceToken = tokenString == null
-                ? null
-                : context.getSession().tokens().decode(tokenString, TrustedDeviceToken.class);
-
-        if (deviceToken != null && deviceToken.getExp() > Time.currentTime()) {
-            boolean tokenIsValid = context.getUser().credentialManager()
-                    .getStoredCredentialsByTypeStream(TrustedDeviceCredentialModel.TYPE)
-                    .map(TrustedDeviceCredentialModel::createFromCredentialModel)
-                    .anyMatch(c -> c.getDeviceId().equals(deviceToken.getDeviceId()) && c.getExpireTime() > Time.currentTime());
-            if (tokenIsValid) {
-                context.success();
-                return;
-            }
+        TrustedDeviceCredentialProvider provider = (TrustedDeviceCredentialProvider)
+                context.getSession().getProvider(CredentialProvider.class, TrustedDeviceCredentialProviderFactory.PROVIDER_ID);
+        if (provider.isTrustedDevice(context.getSession(), context.getRealm(), context.getUser())) {
+            context.success();
+            return;
         }
 
         context.getUser().addRequiredAction(TrustedDeviceRegisterRequiredAction.PROVIDER_ID);

--- a/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceRegisterAuthenticatorFactory.java
+++ b/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceRegisterAuthenticatorFactory.java
@@ -1,0 +1,81 @@
+package netzbegruenung.keycloak.trusteddevice;
+
+import java.util.List;
+
+import netzbegruenung.keycloak.trusteddevice.credentials.TrustedDeviceCredentialModel;
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+public class TrustedDeviceRegisterAuthenticatorFactory implements AuthenticatorFactory {
+
+    public static final String PROVIDER_ID = "nb-trusted-device-register";
+    private static final TrustedDeviceRegisterAuthenticator SINGLETON = new TrustedDeviceRegisterAuthenticator();
+
+    private static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
+            AuthenticationExecutionModel.Requirement.REQUIRED,
+            AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+            AuthenticationExecutionModel.Requirement.DISABLED
+    };
+
+    @Override
+    public String getDisplayType() {
+        return "Trusted Device Register";
+    }
+
+    @Override
+    public String getReferenceCategory() {
+        return TrustedDeviceCredentialModel.TYPE;
+    }
+
+    @Override
+    public boolean isConfigurable() {
+        return false;
+    }
+
+    @Override
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return REQUIREMENT_CHOICES;
+    }
+
+    @Override
+    public boolean isUserSetupAllowed() {
+        return true;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Asks the user if they want to remember this device. If they agree, a cookie is set for the configured duration.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return List.of();
+    }
+
+    @Override
+    public Authenticator create(KeycloakSession session) {
+        return SINGLETON;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+}

--- a/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceRegisterRequiredAction.java
+++ b/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceRegisterRequiredAction.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 
 import netzbegruenung.keycloak.trusteddevice.credentials.TrustedDeviceCredentialModel;
+import org.jboss.logging.Logger;
 import org.keycloak.Config;
 import org.keycloak.authentication.CredentialRegistrator;
 import org.keycloak.authentication.RequiredActionContext;
@@ -38,6 +39,8 @@ import org.keycloak.userprofile.ValidationException;
 import org.keycloak.validate.ValidationError;
 
 public class TrustedDeviceRegisterRequiredAction implements RequiredActionProvider, RequiredActionFactory, CredentialRegistrator {
+
+    private static final Logger logger = Logger.getLogger(TrustedDeviceRegisterRequiredAction.class);
 
     public static final String PROVIDER_ID = "nb-trust-device";
     public static final String CONF_DURATION = "duration";
@@ -188,8 +191,11 @@ public class TrustedDeviceRegisterRequiredAction implements RequiredActionProvid
             if (days >= 1 && days <= MAX_DURATION_DAYS) {
                 return days;
             }
+            logger.warnf("Configured '%s' value %d is out of range (1-%d), falling back to the %d-day default",
+                    CONF_DURATION, days, MAX_DURATION_DAYS, DEFAULT_DURATION_DAYS);
         } catch (NumberFormatException e) {
-            // fall through to default below
+            logger.warnf("Configured '%s' value '%s' is not a number, falling back to the %d-day default",
+                    CONF_DURATION, value, DEFAULT_DURATION_DAYS);
         }
         return DEFAULT_DURATION_DAYS;
     }

--- a/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceRegisterRequiredAction.java
+++ b/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceRegisterRequiredAction.java
@@ -1,0 +1,188 @@
+package netzbegruenung.keycloak.trusteddevice;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+
+import netzbegruenung.keycloak.trusteddevice.credentials.TrustedDeviceCredentialModel;
+import org.keycloak.Config;
+import org.keycloak.authentication.CredentialRegistrator;
+import org.keycloak.authentication.RequiredActionContext;
+import org.keycloak.authentication.RequiredActionFactory;
+import org.keycloak.authentication.RequiredActionProvider;
+import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.SecretGenerator;
+import org.keycloak.common.util.Time;
+import org.keycloak.credential.CredentialModel;
+import org.keycloak.credential.CredentialProvider;
+import org.keycloak.device.DeviceRepresentationProvider;
+import org.keycloak.events.Details;
+import org.keycloak.events.EventBuilder;
+import org.keycloak.events.EventType;
+import org.keycloak.locale.LocaleSelectorProvider;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.UserModel;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+import org.keycloak.representations.account.DeviceRepresentation;
+import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.theme.DateTimeFormatterUtil;
+
+public class TrustedDeviceRegisterRequiredAction implements RequiredActionProvider, RequiredActionFactory, CredentialRegistrator {
+
+    public static final String PROVIDER_ID = "nb-trust-device";
+    public static final String CONF_DURATION = "duration";
+    private static final String AUTH_NOTE_TRUSTED_DEVICE_NAME = "trusted-device-name";
+
+    @Override
+    public String getDisplayText() {
+        return "Manage Trusted Device";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigMetadata() {
+        List<ProviderConfigProperty> config = new ArrayList<>(RequiredActionFactory.MAX_AUTH_AGE_CONFIG_PROPERTIES);
+
+        config.addAll(ProviderConfigurationBuilder.create()
+                .property()
+                .name(CONF_DURATION)
+                .label("Trust duration (days)")
+                .helpText("Duration the device will be trusted in number of days. After this period, the user will be prompted again to trust the device.")
+                .type(ProviderConfigProperty.INTEGER_TYPE)
+                .defaultValue(7)
+                .add()
+                .build());
+
+        return config;
+    }
+
+    @Override
+    public RequiredActionProvider create(KeycloakSession session) {
+        return this;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public void evaluateTriggers(RequiredActionContext context) {
+    }
+
+    @Override
+    public void requiredActionChallenge(RequiredActionContext context) {
+        DeviceRepresentation deviceRepresentation = context
+                .getSession()
+                .getProvider(DeviceRepresentationProvider.class)
+                .deviceRepresentation();
+        String deviceName = createDeviceName(deviceRepresentation);
+        context.getAuthenticationSession().setAuthNote(AUTH_NOTE_TRUSTED_DEVICE_NAME, deviceName);
+
+        Response form = context.form()
+                .setAttribute("deviceName", deviceName)
+                .createForm("trusted-device-register.ftl");
+        context.challenge(form);
+    }
+
+    private String createDeviceName(DeviceRepresentation deviceRep) {
+        StringBuilder deviceName = new StringBuilder();
+
+        String os = deviceRep.getOs();
+        if (os == null || os.toLowerCase().contains("unknown")) {
+            deviceName.append("Unknown Operating System");
+        } else {
+            deviceName.append(os);
+        }
+
+        String osVersion = deviceRep.getOsVersion();
+        if (osVersion != null && !osVersion.toLowerCase().contains("unknown")) {
+            deviceName.append(" ").append(osVersion);
+        }
+
+        deviceName.append(" / ");
+
+        String browser = deviceRep.getBrowser();
+        deviceName.append(Objects.requireNonNullElse(browser, "Unknown Browser"));
+
+        return deviceName.toString();
+    }
+
+    @Override
+    public void processAction(RequiredActionContext context) {
+        MultivaluedMap<String, String> formParameters = context.getHttpRequest().getDecodedFormParameters();
+        EventBuilder event = context.getEvent();
+
+        boolean trustedDevice = "yes".equals(formParameters.getFirst("trusted-device"));
+
+        if (trustedDevice) {
+            event.event(EventType.UPDATE_CREDENTIAL);
+            event.detail(Details.CREDENTIAL_TYPE, TrustedDeviceCredentialModel.TYPE);
+            String deviceName = context.getAuthenticationSession().getAuthNote(AUTH_NOTE_TRUSTED_DEVICE_NAME);
+            if (deviceName == null) {
+                DeviceRepresentation deviceRepresentation = context
+                        .getSession()
+                        .getProvider(DeviceRepresentationProvider.class)
+                        .deviceRepresentation();
+                deviceName = createDeviceName(deviceRepresentation);
+            }
+            int durationInDays = Integer.parseInt(context.getConfig().getConfigValue(CONF_DURATION, "7"));
+            int durationInSeconds = durationInDays * 24 * 60 * 60;
+
+            TrustedDeviceToken token = createDeviceToken(context, deviceName, durationInSeconds);
+
+            TrustedDeviceCookie.write(context.getSession(), context.getSession().tokens().encode(token), durationInSeconds);
+        } else {
+            event.event(EventType.UPDATE_CREDENTIAL_ERROR);
+            event.detail(Details.CREDENTIAL_TYPE, TrustedDeviceCredentialModel.TYPE);
+            event.detail(Details.REASON, "user_declined");
+        }
+
+        context.success();
+    }
+
+    private TrustedDeviceToken createDeviceToken(RequiredActionContext context, String deviceName, int duration) {
+        UserModel user = context.getUser();
+        String deviceId = Base64Url.encode(SecretGenerator.getInstance().randomBytes(SecretGenerator.SECRET_LENGTH_256_BITS));
+        TrustedDeviceCredentialProvider trustedDeviceCredentialProvider =
+                (TrustedDeviceCredentialProvider) context.getSession().getProvider(CredentialProvider.class, TrustedDeviceCredentialProviderFactory.PROVIDER_ID);
+
+        long exp = Time.currentTime() + duration;
+        Locale userLocale = context.getSession().getProvider(LocaleSelectorProvider.class).resolveLocale(context.getRealm(), user);
+        String credentialName = String.format("%s (Expires: %s)", deviceName,
+                DateTimeFormatterUtil.getDateTimeFromMillis(exp * 1000L, userLocale));
+
+        TrustedDeviceCredentialModel trustedDeviceCredentialModel = TrustedDeviceCredentialModel.create(
+                credentialName, deviceId, exp);
+
+        CredentialModel credential = trustedDeviceCredentialProvider.createCredential(context.getRealm(), user, trustedDeviceCredentialModel);
+        user.credentialManager().moveStoredCredentialTo(credential.getId(), null);
+        TrustedDeviceToken token = new TrustedDeviceToken(credential.getId(), deviceId, exp);
+        token.issuer(context.getUriInfo().getBaseUri().toString());
+        token.subject(user.getId());
+
+        return token;
+    }
+
+    @Override
+    public String getCredentialType(KeycloakSession session, AuthenticationSessionModel authenticationSession) {
+        return TrustedDeviceCredentialModel.TYPE;
+    }
+}

--- a/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceRegisterRequiredAction.java
+++ b/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceRegisterRequiredAction.java
@@ -26,17 +26,23 @@ import org.keycloak.events.EventType;
 import org.keycloak.locale.LocaleSelectorProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RequiredActionConfigModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.provider.ProviderConfigurationBuilder;
 import org.keycloak.representations.account.DeviceRepresentation;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.theme.DateTimeFormatterUtil;
+import org.keycloak.userprofile.ValidationException;
+import org.keycloak.validate.ValidationError;
 
 public class TrustedDeviceRegisterRequiredAction implements RequiredActionProvider, RequiredActionFactory, CredentialRegistrator {
 
     public static final String PROVIDER_ID = "nb-trust-device";
     public static final String CONF_DURATION = "duration";
+    private static final int DEFAULT_DURATION_DAYS = 7;
+    private static final int MAX_DURATION_DAYS = 365;
     private static final String AUTH_NOTE_TRUSTED_DEVICE_NAME = "trusted-device-name";
 
     @Override
@@ -52,13 +58,31 @@ public class TrustedDeviceRegisterRequiredAction implements RequiredActionProvid
                 .property()
                 .name(CONF_DURATION)
                 .label("Trust duration (days)")
-                .helpText("Duration the device will be trusted in number of days. After this period, the user will be prompted again to trust the device.")
+                .helpText("Duration the device will be trusted in number of days (1-" + MAX_DURATION_DAYS + "). After this period, the user will be prompted again to trust the device.")
                 .type(ProviderConfigProperty.INTEGER_TYPE)
-                .defaultValue(7)
+                .defaultValue(DEFAULT_DURATION_DAYS)
                 .add()
                 .build());
 
         return config;
+    }
+
+    @Override
+    public void validateConfig(KeycloakSession session, RealmModel realm, RequiredActionConfigModel model) {
+        if (!model.containsConfigKey(CONF_DURATION)) {
+            return;
+        }
+
+        long days;
+        try {
+            days = Long.parseLong(model.getConfigValue(CONF_DURATION));
+        } catch (NumberFormatException e) {
+            throw new ValidationException(new ValidationError(getId(), CONF_DURATION, "error-invalid-value"));
+        }
+
+        if (days < 1 || days > MAX_DURATION_DAYS) {
+            throw new ValidationException(new ValidationError(getId(), CONF_DURATION, "error-number-out-of-range", 1, MAX_DURATION_DAYS));
+        }
     }
 
     @Override
@@ -143,12 +167,12 @@ public class TrustedDeviceRegisterRequiredAction implements RequiredActionProvid
                         .deviceRepresentation();
                 deviceName = createDeviceName(deviceRepresentation);
             }
-            int durationInDays = Integer.parseInt(context.getConfig().getConfigValue(CONF_DURATION, "7"));
-            int durationInSeconds = durationInDays * 24 * 60 * 60;
+            long durationInDays = parseDurationDays(context.getConfig().getConfigValue(CONF_DURATION, String.valueOf(DEFAULT_DURATION_DAYS)));
+            long durationInSeconds = durationInDays * 24 * 60 * 60;
 
             TrustedDeviceToken token = createDeviceToken(context, deviceName, durationInSeconds);
 
-            TrustedDeviceCookie.write(context.getSession(), context.getSession().tokens().encode(token), durationInSeconds);
+            TrustedDeviceCookie.write(context.getSession(), context.getSession().tokens().encode(token), (int) durationInSeconds);
         } else {
             event.event(EventType.UPDATE_CREDENTIAL_ERROR);
             event.detail(Details.CREDENTIAL_TYPE, TrustedDeviceCredentialModel.TYPE);
@@ -158,7 +182,19 @@ public class TrustedDeviceRegisterRequiredAction implements RequiredActionProvid
         context.success();
     }
 
-    private TrustedDeviceToken createDeviceToken(RequiredActionContext context, String deviceName, int duration) {
+    private long parseDurationDays(String value) {
+        try {
+            long days = Long.parseLong(value);
+            if (days >= 1 && days <= MAX_DURATION_DAYS) {
+                return days;
+            }
+        } catch (NumberFormatException e) {
+            // fall through to default below
+        }
+        return DEFAULT_DURATION_DAYS;
+    }
+
+    private TrustedDeviceToken createDeviceToken(RequiredActionContext context, String deviceName, long duration) {
         UserModel user = context.getUser();
         String deviceId = Base64Url.encode(SecretGenerator.getInstance().randomBytes(SecretGenerator.SECRET_LENGTH_256_BITS));
         TrustedDeviceCredentialProvider trustedDeviceCredentialProvider =

--- a/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceToken.java
+++ b/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceToken.java
@@ -1,0 +1,29 @@
+package netzbegruenung.keycloak.trusteddevice;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.keycloak.common.util.Time;
+import org.keycloak.representations.JsonWebToken;
+
+public class TrustedDeviceToken extends JsonWebToken {
+
+    @JsonProperty("device_id")
+    private String deviceId;
+
+    public TrustedDeviceToken() {
+    }
+
+    public TrustedDeviceToken(String id, String deviceId, Long exp) {
+        this.id = id;
+        this.deviceId = deviceId;
+        iat((long) Time.currentTime());
+        exp(exp);
+    }
+
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    public void setDeviceId(String deviceId) {
+        this.deviceId = deviceId;
+    }
+}

--- a/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/credentials/TrustedDeviceCredentialData.java
+++ b/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/credentials/TrustedDeviceCredentialData.java
@@ -1,0 +1,17 @@
+package netzbegruenung.keycloak.trusteddevice.credentials;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TrustedDeviceCredentialData {
+    private final Long expireTime;
+
+    @JsonCreator
+    public TrustedDeviceCredentialData(@JsonProperty("expireTime") Long expireTime) {
+        this.expireTime = expireTime;
+    }
+
+    public Long getExpireTime() {
+        return expireTime;
+    }
+}

--- a/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/credentials/TrustedDeviceCredentialModel.java
+++ b/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/credentials/TrustedDeviceCredentialModel.java
@@ -1,0 +1,72 @@
+package netzbegruenung.keycloak.trusteddevice.credentials;
+
+import java.io.IOException;
+
+import org.keycloak.common.util.Time;
+import org.keycloak.credential.CredentialModel;
+import org.keycloak.util.JsonSerialization;
+
+public class TrustedDeviceCredentialModel extends CredentialModel {
+    public static final String TYPE = "nb-trusted-device";
+
+    private final TrustedDeviceCredentialData credentialData;
+    private final TrustedDeviceSecretData secretData;
+
+    private TrustedDeviceCredentialModel(TrustedDeviceCredentialData credentialData,
+                                          TrustedDeviceSecretData secretData) {
+        this.credentialData = credentialData;
+        this.secretData = secretData;
+    }
+
+    public Long getExpireTime() {
+        return credentialData.getExpireTime();
+    }
+
+    public String getDeviceId() {
+        return secretData.getDeviceId();
+    }
+
+    public static TrustedDeviceCredentialModel create(String userLabel, String deviceId, Long expireTime) {
+        TrustedDeviceCredentialData trustedDeviceCredentialData = new TrustedDeviceCredentialData(expireTime);
+        TrustedDeviceSecretData trustedDeviceSecretData = new TrustedDeviceSecretData(deviceId);
+        TrustedDeviceCredentialModel credentialModel = new TrustedDeviceCredentialModel(
+                trustedDeviceCredentialData, trustedDeviceSecretData);
+
+        credentialModel.setType(TYPE);
+        credentialModel.fillCredentialModelFields();
+        credentialModel.setUserLabel(userLabel);
+
+        return credentialModel;
+    }
+
+    public static TrustedDeviceCredentialModel createFromCredentialModel(CredentialModel credentialModel) {
+        try {
+            TrustedDeviceCredentialData credentialData = JsonSerialization.readValue(
+                    credentialModel.getCredentialData(), TrustedDeviceCredentialData.class);
+            TrustedDeviceSecretData secretData = JsonSerialization.readValue(
+                    credentialModel.getSecretData(), TrustedDeviceSecretData.class);
+
+            TrustedDeviceCredentialModel trustedDeviceCredentialModel = new TrustedDeviceCredentialModel(
+                    credentialData, secretData);
+            trustedDeviceCredentialModel.setUserLabel(credentialModel.getUserLabel());
+            trustedDeviceCredentialModel.setCreatedDate(credentialModel.getCreatedDate());
+            trustedDeviceCredentialModel.setType(credentialModel.getType());
+            trustedDeviceCredentialModel.setId(credentialModel.getId());
+            trustedDeviceCredentialModel.setSecretData(credentialModel.getSecretData());
+            trustedDeviceCredentialModel.setCredentialData(credentialModel.getCredentialData());
+            return trustedDeviceCredentialModel;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void fillCredentialModelFields() {
+        try {
+            setCredentialData(JsonSerialization.writeValueAsString(credentialData));
+            setSecretData(JsonSerialization.writeValueAsString(secretData));
+            setCreatedDate(Time.currentTimeMillis());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/credentials/TrustedDeviceSecretData.java
+++ b/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/credentials/TrustedDeviceSecretData.java
@@ -1,0 +1,17 @@
+package netzbegruenung.keycloak.trusteddevice.credentials;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TrustedDeviceSecretData {
+    private final String deviceId;
+
+    @JsonCreator
+    public TrustedDeviceSecretData(@JsonProperty("deviceId") String deviceId) {
+        this.deviceId = deviceId;
+    }
+
+    public String getDeviceId() {
+        return deviceId;
+    }
+}

--- a/trusted-device-authenticator/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/trusted-device-authenticator/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -1,0 +1,2 @@
+netzbegruenung.keycloak.trusteddevice.TrustedDeviceAuthenticatorFactory
+netzbegruenung.keycloak.trusteddevice.TrustedDeviceRegisterAuthenticatorFactory

--- a/trusted-device-authenticator/src/main/resources/META-INF/services/org.keycloak.authentication.RequiredActionFactory
+++ b/trusted-device-authenticator/src/main/resources/META-INF/services/org.keycloak.authentication.RequiredActionFactory
@@ -1,0 +1,1 @@
+netzbegruenung.keycloak.trusteddevice.TrustedDeviceRegisterRequiredAction

--- a/trusted-device-authenticator/src/main/resources/META-INF/services/org.keycloak.credential.CredentialProviderFactory
+++ b/trusted-device-authenticator/src/main/resources/META-INF/services/org.keycloak.credential.CredentialProviderFactory
@@ -1,0 +1,1 @@
+netzbegruenung.keycloak.trusteddevice.TrustedDeviceCredentialProviderFactory

--- a/trusted-device-authenticator/src/main/resources/theme-resources/messages/messages_de.properties
+++ b/trusted-device-authenticator/src/main/resources/theme-resources/messages/messages_de.properties
@@ -1,0 +1,5 @@
+trustedDeviceHeader=Diesem Gerät vertrauen?
+trustedDeviceExplanation=Vertrauenswürdige Geräte benötigen keinen zweiten Faktor. Vertraue keinen öffentlichen oder gemeinsam genutzten Geräten.
+deviceNameLabel=Gerätename
+trustedDeviceDisplayName=Vertrauenswürdiges Gerät
+trustedDeviceHelpText=Vertrauenswürdige Geräte werden automatisch erkannt.

--- a/trusted-device-authenticator/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/trusted-device-authenticator/src/main/resources/theme-resources/messages/messages_en.properties
@@ -1,0 +1,5 @@
+trustedDeviceHeader=Trust this device?
+trustedDeviceExplanation=Trusted devices do not need a second factor. Do not trust public or shared machines.
+deviceNameLabel=Device name
+trustedDeviceDisplayName=Trusted device
+trustedDeviceHelpText=Trusted devices are verified automatically.

--- a/trusted-device-authenticator/src/main/resources/theme-resources/templates/trusted-device-register.ftl
+++ b/trusted-device-authenticator/src/main/resources/theme-resources/templates/trusted-device-register.ftl
@@ -1,0 +1,24 @@
+<#import "template.ftl" as layout>
+<#import "buttons.ftl" as buttons>
+<#import "field.ftl" as field>
+<@layout.registrationLayout displayInfo=true; section>
+    <#if section = "header">
+        ${msg("trustedDeviceHeader")}
+    <#elseif section="form">
+        <form class="${properties.kcFormClass}" action="${url.loginAction}" method="POST">
+            <@field.group name="trusted-device-name-group" label=msg("deviceNameLabel")>
+                <div class="${properties.kcInputWrapperClass!}">
+                    <p id="kc-trusted-device-name" class="${properties.kcFormHelperTextClass!}">${deviceName}</p>
+                </div>
+            </@field.group>
+            <@buttons.actionGroup>
+                <@buttons.button id="kc-trusted-device-yes" name="trusted-device" label="doYes" value="yes"/>
+                <@buttons.button id="kc-trusted-device-no" name="trusted-device" label="doNo" value="no" class=["kcButtonSecondaryClass"]/>
+            </@buttons.actionGroup>
+        </form>
+    <#elseif section="info">
+        <div id="kc-form-help-text-after-trusted-device" class="${properties.kcLoginMainFooterHelperText!}" aria-live="polite">
+            ${msg("trustedDeviceExplanation")}
+        </div>
+    </#if>
+</@layout.registrationLayout>

--- a/trusted-device-authenticator/src/test/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceLoginFlowTest.java
+++ b/trusted-device-authenticator/src/test/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceLoginFlowTest.java
@@ -1,0 +1,190 @@
+package netzbegruenung.keycloak.trusteddevice;
+
+import netzbegruenung.keycloak.trusteddevice.credentials.TrustedDeviceCredentialModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.events.Details;
+import org.keycloak.events.EventType;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.testframework.annotations.InjectEvents;
+import org.keycloak.testframework.annotations.InjectKeycloakUrls;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.InjectUser;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.annotations.TestSetup;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.events.EventAssertion;
+import org.keycloak.testframework.events.Events;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.ManagedUser;
+import org.keycloak.testframework.realm.UserConfig;
+import org.keycloak.testframework.realm.UserConfigBuilder;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.testframework.server.KeycloakUrls;
+import org.keycloak.testframework.ui.annotations.InjectPage;
+import org.keycloak.testframework.ui.annotations.InjectWebDriver;
+import org.keycloak.testframework.ui.page.LoginPage;
+import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
+import org.keycloak.testsuite.util.FlowUtil;
+import org.openqa.selenium.Cookie;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+@KeycloakIntegrationTest(config = TrustedDeviceLoginFlowTest.ServerConfig.class)
+public class TrustedDeviceLoginFlowTest {
+
+    @InjectRealm
+    ManagedRealm managedRealm;
+
+    @InjectUser(config = LoginFlowUserConfig.class, lifecycle = LifeCycle.METHOD)
+    ManagedUser user;
+
+    @InjectRunOnServer(permittedPackages = "netzbegruenung.keycloak.trusteddevice")
+    RunOnServerClient runOnServer;
+
+    @InjectWebDriver
+    ManagedWebDriver driver;
+
+    @InjectOAuthClient
+    OAuthClient oauth;
+
+    @InjectEvents
+    Events events;
+
+    @InjectPage
+    LoginPage loginPage;
+
+    @InjectPage
+    TrustedDeviceRegisterPage trustDevicePage;
+
+    @InjectKeycloakUrls
+    KeycloakUrls keycloakUrls;
+
+    @TestSetup
+    public void setUpFlow() {
+        TrustedDeviceTestSupport.registerRequiredAction(managedRealm, TrustedDeviceRegisterRequiredAction.PROVIDER_ID);
+
+        runOnServer.run(session -> FlowUtil.inCurrentRealm(session).copyBrowserFlow("browser-trusted-device-flow"));
+        runOnServer.run(session -> FlowUtil.inCurrentRealm(session)
+                .selectFlow("browser-trusted-device-flow")
+                .inForms(forms -> forms
+                        .clear()
+                        .addSubFlowExecution(AuthenticationExecutionModel.Requirement.REQUIRED, subflow -> subflow
+                                .addAuthenticatorExecution(AuthenticationExecutionModel.Requirement.REQUIRED, "auth-username-password-form")
+                                .addSubFlowExecution(AuthenticationExecutionModel.Requirement.REQUIRED, trustedOrRegister -> trustedOrRegister
+                                        .addAuthenticatorExecution(AuthenticationExecutionModel.Requirement.ALTERNATIVE, TrustedDeviceAuthenticatorFactory.PROVIDER_ID)
+                                        .addAuthenticatorExecution(AuthenticationExecutionModel.Requirement.ALTERNATIVE, TrustedDeviceRegisterAuthenticatorFactory.PROVIDER_ID)
+                                )
+                        )
+                )
+                .defineAsBrowserFlow());
+    }
+
+    @BeforeEach
+    public void clearBrowserState() {
+        // navigate to the Keycloak origin first - deleteAllCookies() only clears cookies visible
+        // from the browser's current domain, which may still be a leftover page from a prior test.
+        driver.open(keycloakUrls.getBase());
+        driver.cookies().deleteAll();
+        events.clear();
+    }
+
+    @Test
+    public void firstLoginRegistersDevice() {
+        loginAndTrustDevice();
+    }
+
+    @Test
+    public void secondLoginWithCookieBypassesRegister() {
+        loginAndTrustDevice();
+        logout();
+        events.clear();
+
+        oauth.openLoginForm();
+        loginPage.fillLogin(user.getUsername(), user.getPassword());
+        loginPage.submit();
+
+        EventAssertion.assertSuccess(events.poll())
+                .type(EventType.LOGIN)
+                .userId(user.getId())
+                .details(Details.USERNAME, user.getUsername());
+    }
+
+    @Test
+    public void decliningNeverSetsCookie() {
+        loginAndDeclineDevice();
+        logout();
+        events.clear();
+
+        loginAndDeclineDevice();
+    }
+
+    private void loginAndTrustDevice() {
+        oauth.openLoginForm();
+        loginPage.assertCurrent();
+        loginPage.fillLogin(user.getUsername(), user.getPassword());
+        loginPage.submit();
+
+        trustDevicePage.assertCurrent();
+        trustDevicePage.confirmDevice();
+
+        EventAssertion.assertSuccess(events.poll())
+                .type(EventType.UPDATE_CREDENTIAL)
+                .userId(user.getId())
+                .details(Details.CREDENTIAL_TYPE, TrustedDeviceCredentialModel.TYPE);
+
+        driver.open(keycloakUrls.getBase() + "/realms/" + managedRealm.getName() + "/account");
+        Cookie cookie = driver.cookies().get(TrustedDeviceCookie.NAME);
+        assertThat("TRUSTED_DEVICE cookie should be set after confirming", cookie, notNullValue());
+    }
+
+    private void loginAndDeclineDevice() {
+        oauth.openLoginForm();
+        loginPage.assertCurrent();
+        loginPage.fillLogin(user.getUsername(), user.getPassword());
+        loginPage.submit();
+
+        trustDevicePage.assertCurrent();
+        trustDevicePage.rejectDevice();
+
+        EventAssertion.assertError(events.poll())
+                .type(EventType.UPDATE_CREDENTIAL_ERROR)
+                .userId(user.getId())
+                .details(Details.CREDENTIAL_TYPE, TrustedDeviceCredentialModel.TYPE)
+                .details(Details.REASON, "user_declined");
+
+        driver.open(keycloakUrls.getBase() + "/realms/" + managedRealm.getName() + "/account");
+        Cookie cookie = driver.cookies().get(TrustedDeviceCookie.NAME);
+        assertThat("TRUSTED_DEVICE cookie should not be set after declining", cookie, nullValue());
+    }
+
+    private void logout() {
+        managedRealm.admin().users().get(user.getId()).logout();
+    }
+
+    public static class LoginFlowUserConfig implements UserConfig {
+        @Override
+        public UserConfigBuilder configure(UserConfigBuilder user) {
+            return user.username("login-flow-user")
+                    .password("password")
+                    .name("Login", "Flow")
+                    .email("login-flow@example.com")
+                    .emailVerified(true);
+        }
+    }
+
+    public static class ServerConfig implements KeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.dependencyCurrentProject()
+                    .dependency("org.keycloak.tests", "keycloak-tests-utils-shared");
+        }
+    }
+}

--- a/trusted-device-authenticator/src/test/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceRegisterPage.java
+++ b/trusted-device-authenticator/src/test/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceRegisterPage.java
@@ -1,0 +1,35 @@
+package netzbegruenung.keycloak.trusteddevice;
+
+import org.keycloak.testframework.ui.page.AbstractLoginPage;
+import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+public class TrustedDeviceRegisterPage extends AbstractLoginPage {
+
+    @FindBy(id = "kc-trusted-device-yes")
+    private WebElement trustButton;
+
+    @FindBy(id = "kc-trusted-device-no")
+    private WebElement rejectButton;
+
+    @FindBy(id = "kc-trusted-device-name")
+    private WebElement deviceName;
+
+    public TrustedDeviceRegisterPage(ManagedWebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public String getExpectedPageId() {
+        return "login-trusted-device-register";
+    }
+
+    public void confirmDevice() {
+        trustButton.click();
+    }
+
+    public void rejectDevice() {
+        rejectButton.click();
+    }
+}

--- a/trusted-device-authenticator/src/test/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceRegisterRequiredActionTest.java
+++ b/trusted-device-authenticator/src/test/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceRegisterRequiredActionTest.java
@@ -1,0 +1,137 @@
+package netzbegruenung.keycloak.trusteddevice;
+
+import netzbegruenung.keycloak.trusteddevice.credentials.TrustedDeviceCredentialModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.testframework.annotations.TestSetup;
+import org.keycloak.events.Details;
+import org.keycloak.events.EventType;
+import org.keycloak.representations.idm.EventRepresentation;
+import org.keycloak.testframework.annotations.InjectEvents;
+import org.keycloak.testframework.annotations.InjectKeycloakUrls;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.InjectUser;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.events.EventAssertion;
+import org.keycloak.testframework.events.Events;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.ManagedUser;
+import org.keycloak.testframework.realm.UserConfig;
+import org.keycloak.testframework.realm.UserConfigBuilder;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.testframework.server.KeycloakUrls;
+import org.keycloak.testframework.ui.annotations.InjectPage;
+import org.keycloak.testframework.ui.annotations.InjectWebDriver;
+import org.keycloak.testframework.ui.page.LoginPage;
+import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
+import org.openqa.selenium.Cookie;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+@KeycloakIntegrationTest(config = TrustedDeviceRegisterRequiredActionTest.ServerConfig.class)
+public class TrustedDeviceRegisterRequiredActionTest {
+
+    @InjectRealm
+    ManagedRealm managedRealm;
+
+    @InjectUser(config = RequiredActionUserConfig.class, lifecycle = LifeCycle.METHOD)
+    ManagedUser user;
+
+    @InjectWebDriver
+    ManagedWebDriver driver;
+
+    @InjectOAuthClient
+    OAuthClient oauth;
+
+    @InjectEvents
+    Events events;
+
+    @InjectPage
+    LoginPage loginPage;
+
+    @InjectPage
+    TrustedDeviceRegisterPage trustDevicePage;
+
+    @InjectKeycloakUrls
+    KeycloakUrls keycloakUrls;
+
+    @TestSetup
+    public void registerRequiredAction() {
+        TrustedDeviceTestSupport.registerRequiredAction(managedRealm, TrustedDeviceRegisterRequiredAction.PROVIDER_ID);
+    }
+
+    @BeforeEach
+    public void clearBrowserState() {
+        // navigate to the Keycloak origin first - deleteAllCookies() only clears cookies visible
+        // from the browser's current domain, which may still be a leftover page from a prior test.
+        driver.open(keycloakUrls.getBase());
+        driver.cookies().deleteAll();
+        events.clear();
+    }
+
+    @Test
+    public void declineTrustedDevice() {
+        oauth.openLoginForm();
+        loginPage.fillLogin(user.getUsername(), user.getPassword());
+        loginPage.submit();
+
+        trustDevicePage.assertCurrent();
+        trustDevicePage.rejectDevice();
+
+        EventRepresentation credentialEvent = events.poll();
+        EventAssertion.assertError(credentialEvent)
+                .type(EventType.UPDATE_CREDENTIAL_ERROR)
+                .userId(user.getId())
+                .details(Details.CREDENTIAL_TYPE, TrustedDeviceCredentialModel.TYPE)
+                .details(Details.REASON, "user_declined");
+
+        driver.open(keycloakUrls.getBase() + "/realms/" + managedRealm.getName() + "/account");
+        Cookie cookie = driver.cookies().get(TrustedDeviceCookie.NAME);
+        assertThat("TRUSTED_DEVICE cookie should not be set after declining", cookie, nullValue());
+    }
+
+    @Test
+    public void confirmTrustedDevice() {
+        oauth.openLoginForm();
+        loginPage.fillLogin(user.getUsername(), user.getPassword());
+        loginPage.submit();
+
+        trustDevicePage.assertCurrent();
+        trustDevicePage.confirmDevice();
+
+        EventRepresentation credentialEvent = events.poll();
+        EventAssertion.assertSuccess(credentialEvent)
+                .type(EventType.UPDATE_CREDENTIAL)
+                .userId(user.getId())
+                .details(Details.CREDENTIAL_TYPE, TrustedDeviceCredentialModel.TYPE);
+
+        driver.open(keycloakUrls.getBase() + "/realms/" + managedRealm.getName() + "/account");
+        Cookie cookie = driver.cookies().get(TrustedDeviceCookie.NAME);
+        assertThat("TRUSTED_DEVICE cookie should be set after confirming", cookie, notNullValue());
+    }
+
+    public static class RequiredActionUserConfig implements UserConfig {
+        @Override
+        public UserConfigBuilder configure(UserConfigBuilder user) {
+            return user.username("trusted-device-user")
+                    .password("password")
+                    .name("Trusted", "Device")
+                    .email("trusted-device@example.com")
+                    .emailVerified(true)
+                    .requiredActions(TrustedDeviceRegisterRequiredAction.PROVIDER_ID);
+        }
+    }
+
+    public static class ServerConfig implements KeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.dependencyCurrentProject();
+        }
+    }
+}

--- a/trusted-device-authenticator/src/test/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceTestSupport.java
+++ b/trusted-device-authenticator/src/test/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceTestSupport.java
@@ -1,0 +1,21 @@
+package netzbegruenung.keycloak.trusteddevice;
+
+import org.keycloak.testframework.realm.ManagedRealm;
+
+/**
+ * Custom required actions aren't auto-registered for a realm (only Keycloak's built-in
+ * DefaultRequiredActions are) - an admin normally does this once via "Authentication ->
+ * Required Actions -> register". Tests need the same one-time registration step.
+ */
+final class TrustedDeviceTestSupport {
+
+    private TrustedDeviceTestSupport() {
+    }
+
+    static void registerRequiredAction(ManagedRealm realm, String providerId) {
+        realm.admin().flows().getUnregisteredRequiredActions().stream()
+                .filter(action -> providerId.equals(action.getProviderId()))
+                .findFirst()
+                .ifPresent(action -> realm.admin().flows().registerRequiredAction(action));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `trusted-device-authenticator`: after a successful 2FA login, a user can mark their browser as trusted so future logins from it skip the second factor for a configurable period.

This reimplements the idea from upstream [keycloak/keycloak#48138](https://github.com/keycloak/keycloak/pull/48138), but built entirely on public Keycloak SPI extension points instead of patching Keycloak core, so it ships as a regular provider jar like the other modules here.

## What's included

- Authenticator + factory to validate the trusted-device cookie against a stored credential
- Register-gate authenticator + factory to decide whether the user should be prompted to trust the device
- Required action for the consent screen, credential creation, and cookie issuance
- Credential provider to persist the trusted-device credential (shows up in Account Console's "Signing in" list)
- Cookie helper using the public `HttpRequest`/`HttpResponse` SPI
- Theme resources (FTL + messages) for the consent screen
- Wired into `pom.xml`, `mfa-dev-runner`, CI packaging, and documented in both READMEs

Provider IDs are `nb`-prefixed to avoid clashing if Keycloak ever ships this natively.

## Testing

Integration tests via `keycloak-test-framework` covering registration accept/decline and the full login flow (first-login registration, second-login bypass, decline never sets a cookie).
