### PR TITLE
test(sms-authenticator): add unit and integration test coverage

### DIFF
--- a/sms-authenticator/README.md
+++ b/sms-authenticator/README.md
@@ -46,3 +46,20 @@ account console `/realms/realm/account/#/account-security/signing-in` by enterin
 # Enforce SMS 2FA
 If the option `Force 2FA` in the SMS Authenticator config is enabled and a user has no other 2FA method already enabled,
 users will have to set up the SMS Authenticator.
+
+# Testing
+This module has two kinds of automated tests, both run with `mvn test` from this directory (or `mvn install` from the repo root, which is what CI does):
+
+- **Unit tests** (`ApiSmsServiceTest`) test `ApiSmsService`'s HTTP request building (JSON/urlencoded body, auth header modes, phone number normalization) against a local `HttpServer` stub. No Keycloak involved, runs in well under a second.
+- **Integration tests** (`SmsAuthenticatorFlowTest`) drive the real authenticator through a browser, using [Keycloak's Test Framework](https://www.keycloak.org/docs/latest/server_development/index.html#_testsuite) (`org.keycloak.testframework:*`). It launches a local Keycloak with this module installed as a provider and exercises phone-number setup and login through it, stubbing the outbound SMS gateway call with an in-process `HttpServer` (`@InjectHttpServer`) instead of a real API.
+
+To run only one or the other:
+```shell
+mvn test -Dtest=ApiSmsServiceTest        # unit tests only, fast
+mvn test -Dtest=SmsAuthenticatorFlowTest # integration tests only
+```
+
+Notes on the integration tests:
+- No Docker is required - Keycloak runs as a local process, downloaded and unpacked once into `/tmp/kc-test-framework` and reused across runs.
+- The first run in a clean environment downloads the Keycloak distribution and takes noticeably longer; expect ~30-40s just for Keycloak to boot on top of that.
+- The cached distribution under `/tmp/kc-test-framework` is shared machine-wide across modules. If you switch between testing this module and another one that also uses the Test Framework (e.g. `trusted-device-authenticator`) and hit an unexplained boot failure, delete `/tmp/kc-test-framework` and retry - a stale provider jar from the other module can still be installed alongside this one.

--- a/sms-authenticator/pom.xml
+++ b/sms-authenticator/pom.xml
@@ -12,6 +12,18 @@
         <version>26.6.6</version>
     </parent>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.keycloak.testframework</groupId>
+                <artifactId>keycloak-test-framework-bom</artifactId>
+                <version>${keycloak.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 		<dependency>
 			<groupId>org.keycloak</groupId>
@@ -47,6 +59,37 @@
 			<groupId>com.googlecode.libphonenumber</groupId>
 			<artifactId>libphonenumber</artifactId>
 			<version>9.0.34</version>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak.testframework</groupId>
+			<artifactId>keycloak-test-framework-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak.testframework</groupId>
+			<artifactId>keycloak-test-framework-junit5-config</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak.testframework</groupId>
+			<artifactId>keycloak-test-framework-oauth</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak.testframework</groupId>
+			<artifactId>keycloak-test-framework-ui</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak.testframework</groupId>
+			<artifactId>keycloak-test-framework-remote</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak.tests</groupId>
+			<artifactId>keycloak-tests-utils-shared</artifactId>
+			<version>${keycloak.version}</version>
+			<scope>test</scope>
 		</dependency>
     </dependencies>
 

--- a/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/PhoneNumberSetupPage.java
+++ b/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/PhoneNumberSetupPage.java
@@ -1,0 +1,43 @@
+package netzbegruenung.keycloak.authenticator;
+
+import org.keycloak.testframework.ui.page.AbstractLoginPage;
+import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+/** mobile_number_form.ftl - the phone-number entry form for the mobile_number_config required action. */
+public class PhoneNumberSetupPage extends AbstractLoginPage {
+
+	@FindBy(name = "mobile_number")
+	private WebElement phoneNumberInput;
+
+	public PhoneNumberSetupPage(ManagedWebDriver driver) {
+		super(driver);
+	}
+
+	@Override
+	public String getExpectedPageId() {
+		return "login-mobile_number_form";
+	}
+
+	public void enterPhoneNumber(String phoneNumber) {
+		phoneNumberInput.clear();
+		phoneNumberInput.sendKeys(phoneNumber);
+	}
+
+	/**
+	 * The phone number input's pattern="[0-9\+\-\.\ ]" contains a backslash-escaped space,
+	 * which is invalid ECMAScript syntax under the Unicode-aware regex flags ('u'/'v') the
+	 * HTML spec requires for compiling the pattern attribute - real browsers fail to compile
+	 * it and, per spec, treat the input as if pattern weren't set at all, so this doesn't
+	 * affect real users. HtmlUnit (this framework's WebDriver) compiles the same string in a
+	 * more lenient mode that tolerates the escape, producing a regex that - lacking a
+	 * quantifier - only matches a single character, so a plain click here gets rejected by
+	 * HtmlUnit's own constraint validation. Submitting via the DOM API instead of clicking
+	 * skips that HtmlUnit-specific validation step.
+	 */
+	public void submit() {
+		((JavascriptExecutor) driver.driver()).executeScript("arguments[0].form.submit();", phoneNumberInput);
+	}
+}

--- a/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorFlowTest.java
+++ b/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorFlowTest.java
@@ -1,0 +1,299 @@
+package netzbegruenung.keycloak.authenticator;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.events.Details;
+import org.keycloak.events.EventType;
+import org.keycloak.testframework.annotations.InjectEvents;
+import org.keycloak.testframework.annotations.InjectHttpServer;
+import org.keycloak.testframework.annotations.InjectKeycloakUrls;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.InjectUser;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.annotations.TestSetup;
+import org.keycloak.testframework.events.EventAssertion;
+import org.keycloak.testframework.events.Events;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.ManagedUser;
+import org.keycloak.testframework.realm.UserConfig;
+import org.keycloak.testframework.realm.UserConfigBuilder;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.testframework.server.KeycloakUrls;
+import org.keycloak.testframework.ui.annotations.InjectPage;
+import org.keycloak.testframework.ui.annotations.InjectWebDriver;
+import org.keycloak.testframework.ui.page.ErrorPage;
+import org.keycloak.testframework.ui.page.LoginPage;
+import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
+
+import java.io.InputStream;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @InjectHttpServer hands back a shared JDK HttpServer bound to 127.0.0.1:8500 (see
+ * HttpServerSupplier) that stands in for the SMS gateway ApiSmsService calls out to -
+ * an in-process replacement for a MockServer container, reachable from Keycloak whether
+ * it runs embedded in this JVM or as a local distribution process, since both are on the
+ * same host.
+ */
+@KeycloakIntegrationTest(config = SmsAuthenticatorFlowTest.ServerConfig.class)
+public class SmsAuthenticatorFlowTest {
+
+	private static final String SMS_GATEWAY_PATH = "/sms-authenticator-flow-test/sms";
+	private static final Pattern CODE_PATTERN = Pattern.compile("\\b(\\d{6})\\b");
+
+	@InjectRealm
+	ManagedRealm managedRealm;
+
+	@InjectUser(config = SmsUserConfig.class, lifecycle = LifeCycle.METHOD)
+	ManagedUser user;
+
+	@InjectWebDriver
+	ManagedWebDriver driver;
+
+	@InjectOAuthClient
+	OAuthClient oauth;
+
+	@InjectEvents
+	Events events;
+
+	@InjectPage
+	LoginPage loginPage;
+
+	@InjectPage
+	PhoneNumberSetupPage phoneNumberSetupPage;
+
+	@InjectPage
+	SmsCodePage smsCodePage;
+
+	@InjectPage
+	ErrorPage errorPage;
+
+	@InjectKeycloakUrls
+	KeycloakUrls keycloakUrls;
+
+	@InjectHttpServer
+	HttpServer smsGatewayServer;
+
+	// static: @TestSetup only runs once against the class-scoped realm/HTTP context, but
+	// JUnit5 creates a fresh test instance per method - an instance field here would leave
+	// every instance but the first reading from a queue the shared handler never writes to.
+	private static final LinkedBlockingQueue<String> smsRequestBodies = new LinkedBlockingQueue<>();
+
+	@TestSetup
+	public void setup() {
+		smsGatewayServer.createContext(SMS_GATEWAY_PATH, exchange -> {
+			String body;
+			try (InputStream is = exchange.getRequestBody()) {
+				body = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+			}
+			smsRequestBodies.add(body);
+			exchange.sendResponseHeaders(200, -1);
+			exchange.close();
+		});
+
+		SmsTestSupport.registerRequiredAction(managedRealm, "mobile_number_config");
+		SmsTestSupport.registerRequiredAction(managedRealm, "phone_validation_config");
+
+		Map<String, String> config = new HashMap<>();
+		config.put("apiurl", "http://127.0.0.1:8500" + SMS_GATEWAY_PATH);
+		config.put("urlencode", "true");
+		config.put("messageattribute", "body");
+		config.put("receiverattribute", "to");
+		config.put("senderattribute", "sender");
+		config.put("senderId", "test-sender");
+		config.put("countrycode", "");
+		config.put("length", "6");
+		config.put("ttl", "300");
+		SmsTestSupport.setupSmsBrowserFlow(managedRealm, config);
+	}
+
+	@BeforeEach
+	public void clearState() {
+		driver.open(keycloakUrls.getBase());
+		driver.cookies().deleteAll();
+		events.clear();
+		smsRequestBodies.clear();
+	}
+
+	@Test
+	public void phoneNumberSetupCreatesCredential() throws Exception {
+		registerPhoneNumber();
+
+		// PhoneValidationRequiredAction doesn't fire a dedicated UPDATE_CREDENTIAL event of
+		// its own (unlike e.g. trusted-device-authenticator) - completing the required
+		// action itself is what's observable here; credential creation is verified directly
+		// against the admin API below.
+		EventAssertion.assertSuccess(events.poll())
+			.type(EventType.CUSTOM_REQUIRED_ACTION)
+			.userId(user.getId());
+
+		boolean hasMobileNumberCredential = managedRealm.admin().users().get(user.getId())
+			.credentials()
+			.stream()
+			.anyMatch(credential -> "mobile-number".equals(credential.getType()));
+		assertTrue(hasMobileNumberCredential, "Expected a mobile-number credential after phone number setup");
+	}
+
+	@Test
+	public void secondLoginPromptsForSmsCode() throws Exception {
+		registerPhoneNumber();
+		logout();
+		events.clear();
+
+		oauth.openLoginForm();
+		loginPage.fillLogin(user.getUsername(), user.getPassword());
+		loginPage.submit();
+
+		smsCodePage.assertCurrent();
+		smsCodePage.enterCode(awaitSmsCode());
+		smsCodePage.submit();
+
+		EventAssertion.assertSuccess(events.poll())
+			.type(EventType.LOGIN)
+			.userId(user.getId())
+			.details(Details.USERNAME, user.getUsername());
+	}
+
+	@Test
+	public void invalidSmsCodeIsRejectedAndCanBeRetried() throws Exception {
+		registerPhoneNumber();
+		logout();
+		events.clear();
+
+		oauth.openLoginForm();
+		loginPage.fillLogin(user.getUsername(), user.getPassword());
+		loginPage.submit();
+
+		smsCodePage.assertCurrent();
+		String correctCode = awaitSmsCode();
+		smsCodePage.enterCode("000000".equals(correctCode) ? "111111" : "000000");
+		smsCodePage.submit();
+
+		// Rejected: still on the SMS code page, no successful login event yet.
+		smsCodePage.assertCurrent();
+		events.clear();
+
+		smsCodePage.enterCode(correctCode);
+		smsCodePage.submit();
+
+		EventAssertion.assertSuccess(events.poll())
+			.type(EventType.LOGIN)
+			.userId(user.getId())
+			.details(Details.USERNAME, user.getUsername());
+	}
+
+	@Test
+	public void expiredSmsCodeIsRejected() throws Exception {
+		registerPhoneNumber();
+		logout();
+		events.clear();
+
+		SmsTestSupport.updateSmsExecutionConfig(managedRealm, Map.of("ttl", "2"));
+		try {
+			oauth.openLoginForm();
+			loginPage.fillLogin(user.getUsername(), user.getPassword());
+			loginPage.submit();
+
+			smsCodePage.assertCurrent();
+			String code = awaitSmsCode();
+
+			Thread.sleep(3000);
+
+			smsCodePage.enterCode(code);
+			smsCodePage.submit();
+
+			// SmsAuthenticator.action() treats an expired code as a terminal failure
+			// (createErrorPage), unlike a wrong code which re-challenges the same form.
+			errorPage.assertCurrent();
+			assertTrue(errorPage.getError().contains("expired"), "Expected an expiry error, got: " + errorPage.getError());
+		} finally {
+			SmsTestSupport.updateSmsExecutionConfig(managedRealm, Map.of("ttl", "300"));
+		}
+	}
+
+	private void registerPhoneNumber() throws InterruptedException {
+		oauth.openLoginForm();
+		loginPage.fillLogin(user.getUsername(), user.getPassword());
+		loginPage.submit();
+
+		phoneNumberSetupPage.assertCurrent();
+		phoneNumberSetupPage.enterPhoneNumber("+491234567");
+		phoneNumberSetupPage.submit();
+		// Submitting the phone number fires its own CUSTOM_REQUIRED_ACTION event before the
+		// SMS code step's UPDATE_CREDENTIAL event - clear it so callers only see the latter.
+		events.clear();
+
+		smsCodePage.assertCurrent();
+		smsCodePage.enterCode(awaitSmsCode());
+		smsCodePage.submit();
+	}
+
+	private void logout() {
+		managedRealm.admin().users().get(user.getId()).logout();
+	}
+
+	private String awaitSmsCode() throws InterruptedException {
+		String body = smsRequestBodies.poll(10, TimeUnit.SECONDS);
+		assertNotNull(body, "Expected the SMS gateway stub to receive a request");
+		Map<String, String> form = parseFormData(body);
+		String message = form.get("body");
+		assertThat("Expected the SMS gateway to receive a message body", message, notNullValue());
+		Matcher matcher = CODE_PATTERN.matcher(message);
+		assertTrue(matcher.find(), "Expected a 6-digit code in the SMS body: " + message);
+		return matcher.group(1);
+	}
+
+	private static Map<String, String> parseFormData(String body) {
+		Map<String, String> result = new HashMap<>();
+		for (String pair : body.split("&")) {
+			int idx = pair.indexOf('=');
+			if (idx > 0) {
+				String key = URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8);
+				String value = URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8);
+				result.put(key, value);
+			}
+		}
+		return result;
+	}
+
+	public static class SmsUserConfig implements UserConfig {
+		@Override
+		public UserConfigBuilder configure(UserConfigBuilder user) {
+			return user.username("sms-flow-user")
+				.password("password")
+				.name("Sms", "Flow")
+				.email("sms-flow@example.com")
+				.emailVerified(true)
+				.requiredActions("mobile_number_config");
+		}
+	}
+
+	public static class ServerConfig implements KeycloakServerConfig {
+		@Override
+		public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+			// libphonenumber is bundled into the production provider jar only by the
+			// shade-plugin step (see sms-authenticator/pom.xml); dependencyCurrentProject()
+			// doesn't go through that, so it must be added separately or
+			// PhoneNumberRequiredActionFactory fails to load with NoClassDefFoundError.
+			return config.dependencyCurrentProject()
+				.dependency("com.googlecode.libphonenumber", "libphonenumber");
+		}
+	}
+}

--- a/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/SmsCodePage.java
+++ b/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/SmsCodePage.java
@@ -1,0 +1,38 @@
+package netzbegruenung.keycloak.authenticator;
+
+import org.keycloak.testframework.ui.page.AbstractLoginPage;
+import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * login-sms.ftl (SmsAuthenticator.TPL_CODE). Its code input shares id="code" with
+ * mobile_number_form.ftl's phone-number input, disambiguated here since this page's
+ * input additionally carries type="number".
+ */
+public class SmsCodePage extends AbstractLoginPage {
+
+	@FindBy(id = "code")
+	private WebElement codeInput;
+
+	@FindBy(css = "#kc-sms-code-login-form input[type='submit']")
+	private WebElement submitButton;
+
+	public SmsCodePage(ManagedWebDriver driver) {
+		super(driver);
+	}
+
+	@Override
+	public String getExpectedPageId() {
+		return "login-login-sms";
+	}
+
+	public void enterCode(String code) {
+		codeInput.clear();
+		codeInput.sendKeys(code);
+	}
+
+	public void submit() {
+		submitButton.click();
+	}
+}

--- a/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/SmsTestSupport.java
+++ b/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/SmsTestSupport.java
@@ -1,0 +1,129 @@
+package netzbegruenung.keycloak.authenticator;
+
+import jakarta.ws.rs.core.Response;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.AuthenticationExecutionInfoRepresentation;
+import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
+import org.keycloak.representations.idm.AuthenticatorConfigRepresentation;
+import org.keycloak.testframework.realm.ManagedRealm;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+/**
+ * Wires the mobile-number-authenticator into a copy of the "browser" flow via the admin
+ * REST API. Custom required actions aren't auto-registered for a realm either - an admin
+ * normally does this once via "Authentication -> Required Actions -> register", so tests
+ * need the same one-time registration step.
+ *
+ * PhoneNumberRequiredAction/PhoneValidationRequiredAction look up their authenticator config
+ * by the hardcoded alias "sms-2fa" (see the module README), so the execution's config alias
+ * must be exactly that.
+ */
+final class SmsTestSupport {
+
+	static final String FLOW_ALIAS = "browser-sms";
+	static final String CONFIG_ALIAS = "sms-2fa";
+	private static final String PROVIDER_ID = "mobile-number-authenticator";
+
+	private SmsTestSupport() {
+	}
+
+	static void registerRequiredAction(ManagedRealm realm, String providerId) {
+		realm.admin().flows().getUnregisteredRequiredActions().stream()
+			.filter(action -> providerId.equals(action.getProviderId()))
+			.findFirst()
+			.ifPresent(action -> realm.admin().flows().registerRequiredAction(action));
+	}
+
+	static void setupSmsBrowserFlow(ManagedRealm managedRealm, Map<String, String> smsExecutionConfig) {
+		RealmResource realm = managedRealm.admin();
+
+		AuthenticationFlowRepresentation copiedFlow = copyFlow(realm, "browser", FLOW_ALIAS);
+		AuthenticationExecutionInfoRepresentation conditional2fa = realm.flows().getExecutions(copiedFlow.getAlias())
+			.stream()
+			.filter(e -> e.getDisplayName() != null && e.getDisplayName().contains("Conditional 2FA"))
+			.findFirst()
+			.orElseThrow(() -> new IllegalStateException("Conditional 2FA subflow not found in copied browser flow"));
+
+		AuthenticationExecutionInfoRepresentation smsExecution = addExecution(realm, conditional2fa, PROVIDER_ID,
+			execution -> execution.setRequirement("ALTERNATIVE"));
+
+		createExecutionConfig(realm, smsExecution, config -> {
+			config.setAlias(CONFIG_ALIAS);
+			config.getConfig().putAll(smsExecutionConfig);
+		});
+
+		var realmRepresentation = realm.toRepresentation();
+		realmRepresentation.setBrowserFlow(copiedFlow.getAlias());
+		realm.update(realmRepresentation);
+	}
+
+	static void updateSmsExecutionConfig(ManagedRealm managedRealm, Map<String, String> overrides) {
+		RealmResource realm = managedRealm.admin();
+		AuthenticationExecutionInfoRepresentation execution = findSmsExecution(realm);
+		String configId = execution.getAuthenticationConfig();
+		AuthenticatorConfigRepresentation config = realm.flows().getAuthenticatorConfig(configId);
+		config.getConfig().putAll(overrides);
+		realm.flows().updateAuthenticatorConfig(configId, config);
+	}
+
+	private static AuthenticationExecutionInfoRepresentation findSmsExecution(RealmResource realm) {
+		return realm.flows().getExecutions(FLOW_ALIAS)
+			.stream()
+			.filter(e -> PROVIDER_ID.equals(e.getProviderId()))
+			.findFirst()
+			.orElseThrow(() -> new IllegalStateException("mobile-number-authenticator execution not found in " + FLOW_ALIAS));
+	}
+
+	private static AuthenticationFlowRepresentation copyFlow(RealmResource realm, String originalAlias, String newAlias) {
+		try (Response response = realm.flows().copy(originalAlias, Map.of("newName", newAlias))) {
+			if (response.getStatus() != 201) {
+				throw new IllegalStateException("Failed to copy flow " + originalAlias + ": " + response.getStatus());
+			}
+		}
+		return realm.flows().getFlows().stream()
+			.filter(flow -> newAlias.equals(flow.getAlias()))
+			.findFirst()
+			.orElseThrow();
+	}
+
+	private static AuthenticationExecutionInfoRepresentation addExecution(
+		RealmResource realm,
+		AuthenticationExecutionInfoRepresentation parentExecution,
+		String providerId,
+		Consumer<AuthenticationExecutionInfoRepresentation> executionConsumer
+	) {
+		AuthenticationFlowRepresentation subFlow = realm.flows().getFlow(parentExecution.getFlowId());
+		realm.flows().addExecution(subFlow.getAlias(), Map.of("provider", providerId));
+
+		AuthenticationExecutionInfoRepresentation newExecution = realm.flows().getExecutions(subFlow.getAlias())
+			.stream()
+			.filter(execution -> providerId.equals(execution.getProviderId()))
+			.findFirst()
+			.orElseThrow();
+
+		executionConsumer.accept(newExecution);
+		realm.flows().updateExecutions(subFlow.getAlias(), newExecution);
+		return newExecution;
+	}
+
+	private static void createExecutionConfig(
+		RealmResource realm,
+		AuthenticationExecutionInfoRepresentation execution,
+		Consumer<AuthenticatorConfigRepresentation> configConsumer
+	) {
+		AuthenticatorConfigRepresentation config = new AuthenticatorConfigRepresentation();
+		config.setId(UUID.randomUUID().toString());
+		config.setConfig(new HashMap<>());
+		configConsumer.accept(config);
+
+		try (Response response = realm.flows().newExecutionConfig(execution.getId(), config)) {
+			if (response.getStatus() != 201) {
+				throw new IllegalStateException("Failed to create execution config: " + response.getStatus());
+			}
+		}
+	}
+}

--- a/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/gateway/ApiSmsServiceTest.java
+++ b/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/gateway/ApiSmsServiceTest.java
@@ -1,0 +1,178 @@
+package netzbegruenung.keycloak.authenticator.gateway;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * ApiSmsService.send() talks to the configured "apiurl" via plain java.net.http.HttpClient
+ * and has no Keycloak-runtime dependency, so it's exercised here with a local HttpServer
+ * stub instead of a full Keycloak/browser integration test.
+ */
+class ApiSmsServiceTest {
+
+	private HttpServer server;
+	private final LinkedBlockingQueue<CapturedRequest> requests = new LinkedBlockingQueue<>();
+
+	private record CapturedRequest(String contentType, String authorization, String body) {
+	}
+
+	@BeforeEach
+	void startServer() throws IOException {
+		server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+		server.createContext("/sms", exchange -> {
+			String body;
+			try (InputStream is = exchange.getRequestBody()) {
+				body = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+			}
+			requests.add(new CapturedRequest(
+				exchange.getRequestHeaders().getFirst("Content-Type"),
+				exchange.getRequestHeaders().getFirst("Authorization"),
+				body
+			));
+			exchange.sendResponseHeaders(200, -1);
+			exchange.close();
+		});
+		server.start();
+	}
+
+	@AfterEach
+	void stopServer() {
+		server.stop(0);
+	}
+
+	private String apiUrl() {
+		return "http://localhost:" + server.getAddress().getPort() + "/sms";
+	}
+
+	private CapturedRequest awaitRequest() throws InterruptedException {
+		CapturedRequest request = requests.poll(5, TimeUnit.SECONDS);
+		assertNotNull(request, "Expected the SMS gateway stub to receive a request");
+		return request;
+	}
+
+	private ApiSmsService newService(Map<String, String> overrides) {
+		Map<String, String> config = new HashMap<>();
+		config.put("apiurl", apiUrl());
+		config.put("messageattribute", "body");
+		config.put("receiverattribute", "to");
+		config.put("senderattribute", "sender");
+		config.put("senderId", "test-sender");
+		config.put("countrycode", "");
+		config.putAll(overrides);
+		return new ApiSmsService(config);
+	}
+
+	private static Map<String, String> parseFormData(String body) {
+		Map<String, String> result = new HashMap<>();
+		for (String pair : body.split("&")) {
+			int idx = pair.indexOf('=');
+			if (idx > 0) {
+				String key = URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8);
+				String value = URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8);
+				result.put(key, value);
+			}
+		}
+		return result;
+	}
+
+	@Test
+	@DisplayName("JSON mode sends a JSON body with the configured field names")
+	void jsonModeSendsJsonBody() throws Exception {
+		ApiSmsService service = newService(Map.of("urlencode", "false"));
+
+		service.send("+491234567", "your code is 123456");
+
+		CapturedRequest request = awaitRequest();
+		assertEquals("application/json", request.contentType());
+		assertTrue(request.body().contains("\"body\":\"your code is 123456\""));
+		assertTrue(request.body().contains("\"to\":\"+491234567\""));
+		assertTrue(request.body().contains("\"sender\":\"test-sender\""));
+	}
+
+	@Test
+	@DisplayName("urlencoded mode sends a form-encoded body with the configured field names")
+	void urlencodedModeSendsFormBody() throws Exception {
+		ApiSmsService service = newService(Map.of("urlencode", "true"));
+
+		service.send("+491234567", "your code is 123456");
+
+		CapturedRequest request = awaitRequest();
+		assertEquals("application/x-www-form-urlencoded", request.contentType());
+		Map<String, String> form = parseFormData(request.body());
+		assertEquals("your code is 123456", form.get("body"));
+		assertEquals("+491234567", form.get("to"));
+		assertEquals("test-sender", form.get("sender"));
+	}
+
+	@Test
+	@DisplayName("apiTokenInHeader sends the raw token as the Authorization header value")
+	void apiTokenInHeaderSendsRawToken() throws Exception {
+		ApiSmsService service = newService(Map.of(
+			"urlencode", "false",
+			"apiTokenInHeader", "true",
+			"apitoken", "my-raw-token"
+		));
+
+		service.send("+491234567", "code");
+
+		CapturedRequest request = awaitRequest();
+		assertEquals("my-raw-token", request.authorization());
+	}
+
+	@Test
+	@DisplayName("cleanPhoneNumber: no transformation when countrycode is empty")
+	void cleanPhoneNumberDoesNothingWithoutCountryCode() throws Exception {
+		ApiSmsService service = newService(Map.of("urlencode", "true", "countrycode", ""));
+
+		service.send("0176123456", "code");
+
+		assertEquals("0176123456", parseFormData(awaitRequest().body()).get("to"));
+	}
+
+	@Test
+	@DisplayName("cleanPhoneNumber: 49... is normalised to +49...")
+	void cleanPhoneNumberAddsPlusPrefixToNumberStartingWithCountryCode() throws Exception {
+		ApiSmsService service = newService(Map.of("urlencode", "true", "countrycode", "+49"));
+
+		service.send("49176123456", "code");
+
+		assertEquals("+49176123456", parseFormData(awaitRequest().body()).get("to"));
+	}
+
+	@Test
+	@DisplayName("cleanPhoneNumber: 0049... is normalised to +49...")
+	void cleanPhoneNumberReplacesDoubleZeroPrefixWithPlus() throws Exception {
+		ApiSmsService service = newService(Map.of("urlencode", "true", "countrycode", "+49"));
+
+		service.send("0049176123456", "code");
+
+		assertEquals("+49176123456", parseFormData(awaitRequest().body()).get("to"));
+	}
+
+	@Test
+	@DisplayName("cleanPhoneNumber: 0... is normalised to +49... (national format with leading 0)")
+	void cleanPhoneNumberReplacesLeadingZeroWithCountryCode() throws Exception {
+		ApiSmsService service = newService(Map.of("urlencode", "true", "countrycode", "+49"));
+
+		service.send("0176123456", "code");
+
+		assertEquals("+49176123456", parseFormData(awaitRequest().body()).get("to"));
+	}
+}


### PR DESCRIPTION
## Summary
- Adds fast unit tests for `ApiSmsService`'s request-building logic (body encoding, auth header modes, phone number normalization) against a local `HttpServer` stub - no Keycloak involved.
- Adds Keycloak Test Framework (`org.keycloak.testframework:*`) integration tests covering phone-number setup, a correct-code login, an invalid code, and an expired code, following the same pattern already used by `trusted-device-authenticator`. No Docker required.
- Adds a `Testing` section to `sms-authenticator/README.md` documenting how to run each tier and a known gotcha (the shared `/tmp/kc-test-framework` distribution cache across modules).

Related to #354, which covers similar ground with a testcontainers/Playwright/MockServer-based approach; this uses the first-party Keycloak Test Framework instead, consistent with `trusted-device-authenticator`'s existing tests and not requiring Docker.

## Test plan
- [x] `mvn test -Dtest=ApiSmsServiceTest` - 7/7 unit tests pass
- [x] `mvn test -Dtest=SmsAuthenticatorFlowTest` - 4/4 integration tests pass
- [x] `mvn install` from repo root - full reactor build green, including existing `trusted-device-authenticator` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)