### PR TITLE
docs: switch release versioning to Keycloak version plus counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,31 @@ Deployment is done by github actions: `.github/workflows/release.yml`
 To trigger the release workflow be sure to have proper access rights and follow the steps below.
 https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-tag-protection-rules#about-tag-protection-rules
 
-1. Update project and submodules version `mvn versions:set -DnewVersion=1.2.3; mvn versions:commit`
-1. Commit your changes
-1. Add tag to your commit (removes all ANSI escape codes from maven output)
+### Versioning
+Versions follow `<keycloak.version>-<counter>`, e.g. `26.7.0-0`, rather than independent semantic versioning. The counter starts at `0` for the first release built against a given Keycloak version and increments for any additional release against that same Keycloak version (e.g. a hotfix); it resets to `0` whenever `keycloak.version` is bumped in `pom.xml`.
+
+Run the block below to bump the version, commit, and tag (in IntelliJ you can run it directly from this file):
 ```shell
-VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout \
+set -e
+KEYCLOAK_VERSION=$(mvn help:evaluate -Dexpression=keycloak.version -q -DforceStdout \
   | awk '{gsub(/\x1b\[[0-9;]*[mK]/,""); print}' \
   | tr -d '\r')
-git tag -a "v$VERSION" -m "Bump version $VERSION"
+LAST_COUNTER=$(git tag -l "v${KEYCLOAK_VERSION}-*" \
+  | sed "s/^v${KEYCLOAK_VERSION}-//" \
+  | sort -n | tail -1)
+NEW_VERSION="${KEYCLOAK_VERSION}-$(( ${LAST_COUNTER:--1} + 1 ))"
+mvn versions:set -DnewVersion="$NEW_VERSION"
+mvn versions:commit
+git add -u
+git commit -m "chore: release $NEW_VERSION"
+git tag -a "v$NEW_VERSION" -m "Release $NEW_VERSION"
+echo "Tagged v$NEW_VERSION - review it, then push with: git push --follow-tags"
 ```
-1. Trigger the release by `git push --tags`
 
-After building completes the new release is available on github containing the jar files for each module.
+Review the resulting commit and tag, then trigger the release by pushing both together:
+```shell
+git push --follow-tags
+```
+(`--follow-tags` pushes the commit and the new annotated tag in one step; a plain `git push` would not push the tag on its own, and it's the tag push that triggers the workflow.)
+
+After building completes the new release is available on github containing the jar files for each module. Release notes are auto-generated from merged PRs since the last tag (`gh release create --generate-notes` in the workflow), so any PR description explaining a notable change — like this versioning switch — is automatically surfaced to the community.


### PR DESCRIPTION
## Summary
- Version numbers now follow `<keycloak.version>-<counter>` (e.g. `26.7.0-0`) instead of independent semantic versioning, so multiple releases can target the same Keycloak version (e.g. hotfixes) without inventing an unrelated version number.
- The release steps in the README are now a single `shell` code block runnable directly from the IDE (e.g. IntelliJ's run gutter on fenced code blocks), with `git push` intentionally left out so a release can't be triggered by an accidental click.

This PR only updates the documentation/process — the actual version bump to `26.7.0-0` and its tag will be done in a follow-up commit directly on `main` after this merges, so it shows up in that release's auto-generated notes.