### PR TITLE
Skip SMS authentication when the execution has no config

### DIFF
--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticator.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/SmsAuthenticator.java
@@ -64,6 +64,12 @@ public class SmsAuthenticator implements Authenticator, CredentialValidator<SmsA
 		UserModel user = context.getUser();
 		RealmModel realm = context.getRealm();
 
+		if (config == null || config.getConfig() == null) {
+			logger.errorf("No config found for SMS authenticator execution in realm %s, skip SMS authentication", realm.getName());
+			context.attempted();
+			return;
+		}
+
 		Optional<CredentialModel> model = context.getUser().credentialManager().getStoredCredentialsByTypeStream(SmsAuthCredentialModel.TYPE).findFirst();
 		String mobileNumber;
 		try {


### PR DESCRIPTION
`SmsAuthenticator.authenticate` read `context.getAuthenticatorConfig().getConfig()` unguarded, so an execution with no config attached threw an NPE and hard-failed the login before the error-page fallback could run.

Now it logs an error and calls `context.attempted()`, letting the remaining alternatives in the flow run.

Seen in production: a subflow whose `mobile-number-authenticator` execution had no config, reached by users whose only second factor is SMS. `app-authenticator` already handles a null config the same way.