### PR TITLE
Make device name editable during trusted device registration

### DIFF
--- a/trusted-device-authenticator/README.md
+++ b/trusted-device-authenticator/README.md
@@ -28,7 +28,7 @@ This is an independent reimplementation of the ideas from upstream Keycloak pull
 | Trust duration (days) | Number of days the device stays trusted before the user is asked again. | `7` |
 
 # Usage
-After a user completes their normal second factor, they're asked whether to trust the current device. If they accept, a signed cookie and a matching `netzbegruenung-trusted-device` credential are stored for the user; as long as both are present and unexpired, the `Trusted Device` step succeeds and the second-factor sub-flow is skipped on that browser. The trusted device also shows up in the account console (`/realms/realm/account/#/account-security/signing-in`) and can be revoked there like any other credential.
+After a user completes their normal second factor, they're asked whether to trust the current device. The device name is automatically detected (e.g. "Windows 10 / Chrome") and can be edited before confirming. If they accept, a signed cookie and a matching `netzbegruenung-trusted-device` credential are stored for the user; as long as both are present and unexpired, the `Trusted Device` step succeeds and the second-factor sub-flow is skipped on that browser. The trusted device also shows up in the account console (`/realms/realm/account/#/account-security/signing-in`) and can be revoked there like any other credential.
 
 # License
 Apache License 2.0

--- a/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceRegisterRequiredAction.java
+++ b/trusted-device-authenticator/src/main/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceRegisterRequiredAction.java
@@ -162,13 +162,16 @@ public class TrustedDeviceRegisterRequiredAction implements RequiredActionProvid
         if (trustedDevice) {
             event.event(EventType.UPDATE_CREDENTIAL);
             event.detail(Details.CREDENTIAL_TYPE, TrustedDeviceCredentialModel.TYPE);
-            String deviceName = context.getAuthenticationSession().getAuthNote(AUTH_NOTE_TRUSTED_DEVICE_NAME);
-            if (deviceName == null) {
-                DeviceRepresentation deviceRepresentation = context
-                        .getSession()
-                        .getProvider(DeviceRepresentationProvider.class)
-                        .deviceRepresentation();
-                deviceName = createDeviceName(deviceRepresentation);
+            String deviceName = formParameters.getFirst(AUTH_NOTE_TRUSTED_DEVICE_NAME);
+            if (deviceName == null || deviceName.isBlank()) {
+                deviceName = context.getAuthenticationSession().getAuthNote(AUTH_NOTE_TRUSTED_DEVICE_NAME);
+                if (deviceName == null) {
+                    DeviceRepresentation deviceRepresentation = context
+                            .getSession()
+                            .getProvider(DeviceRepresentationProvider.class)
+                            .deviceRepresentation();
+                    deviceName = createDeviceName(deviceRepresentation);
+                }
             }
             long durationInDays = parseDurationDays(context.getConfig().getConfigValue(CONF_DURATION, String.valueOf(DEFAULT_DURATION_DAYS)));
             long durationInSeconds = durationInDays * 24 * 60 * 60;

--- a/trusted-device-authenticator/src/main/resources/theme-resources/templates/trusted-device-register.ftl
+++ b/trusted-device-authenticator/src/main/resources/theme-resources/templates/trusted-device-register.ftl
@@ -8,7 +8,7 @@
         <form class="${properties.kcFormClass}" action="${url.loginAction}" method="POST">
             <@field.group name="trusted-device-name-group" label=msg("deviceNameLabel")>
                 <div class="${properties.kcInputWrapperClass!}">
-                    <p id="kc-trusted-device-name" class="${properties.kcFormHelperTextClass!}">${deviceName}</p>
+                    <input id="kc-trusted-device-name" name="trusted-device-name" class="${properties.kcInputClass!}" type="text" value="${deviceName}" />
                 </div>
             </@field.group>
             <@buttons.actionGroup>

--- a/trusted-device-authenticator/src/test/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceRegisterPage.java
+++ b/trusted-device-authenticator/src/test/java/netzbegruenung/keycloak/trusteddevice/TrustedDeviceRegisterPage.java
@@ -29,7 +29,17 @@ public class TrustedDeviceRegisterPage extends AbstractLoginPage {
         trustButton.click();
     }
 
+    public void confirmDeviceWithName(String name) {
+        deviceName.clear();
+        deviceName.sendKeys(name);
+        trustButton.click();
+    }
+
     public void rejectDevice() {
         rejectButton.click();
+    }
+
+    public String getDeviceName() {
+        return deviceName.getDomProperty("value");
     }
 }


### PR DESCRIPTION
The device name shown during trusted device registration was previously read-only. Users could see the auto-generated name (e.g. "Windows 10 / Firefox 153") but had no way to customize it.

This PR makes the device name field editable.

### Changes

- `trusted-device-register.ftl`: Replaced the read-only `<p>` element with an `<input type="text">` field. The auto-detected name is pre-filled as the default value.

- `TrustedDeviceRegisterRequiredAction.java`: In `processAction()`, the device name is now read from the submitted form field (`trusted-device-name`) first. If the user left the field blank, it falls back to the current behavior.

- `TrustedDeviceRegisterPage.java` (test): Added `confirmDeviceWithName(String name)` to submit a custom device name, and `getDeviceName()` to read the current input value.

- `README.md`: Updated the usage section to mention that the device name can be edited before confirming.