### PR TITLE
feat(sms): add change-number on enrollment code step

### DIFF
--- a/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/PhoneValidationRequiredAction.java
+++ b/sms-authenticator/src/main/java/netzbegruenung/keycloak/authenticator/PhoneValidationRequiredAction.java
@@ -46,6 +46,9 @@ public class PhoneValidationRequiredAction implements RequiredActionProvider, Cr
 	private static final Logger logger = Logger.getLogger(PhoneValidationRequiredAction.class);
 	public static final String PROVIDER_ID = "phone_validation_config";
 
+	private static final String FORM_ACTION = "sms-action";
+	private static final String ACTION_CHANGE_NUMBER = "change-number";
+
 	@Override
 	public void evaluateTriggers(RequiredActionContext context) {
 	}
@@ -78,10 +81,7 @@ public class PhoneValidationRequiredAction implements RequiredActionProvider, Cr
 
 			SmsServiceFactory.get(config.getConfig()).send(mobileNumber, smsText);
 
-			Response challenge = context.form()
-				.setAttribute("realm", realm)
-				.createForm(SmsAuthenticator.TPL_CODE);
-			context.challenge(challenge);
+			context.challenge(createCodeForm(context, null));
 		} catch (Exception e) {
 			logger.error(e.getMessage(), e);
 			context.failure();
@@ -90,6 +90,11 @@ public class PhoneValidationRequiredAction implements RequiredActionProvider, Cr
 
 	@Override
 	public void processAction(RequiredActionContext context) {
+		if (ACTION_CHANGE_NUMBER.equals(context.getHttpRequest().getDecodedFormParameters().getFirst(FORM_ACTION))) {
+			handleChangeNumber(context);
+			return;
+		}
+
 		String enteredCode = context.getHttpRequest().getDecodedFormParameters().getFirst("code");
 
 		AuthenticationSessionModel authSession = context.getAuthenticationSession();
@@ -125,6 +130,27 @@ public class PhoneValidationRequiredAction implements RequiredActionProvider, Cr
 		}
 	}
 
+	private void handleChangeNumber(RequiredActionContext context) {
+		AuthenticationSessionModel authSession = context.getAuthenticationSession();
+		authSession.removeAuthNote("code");
+		authSession.removeAuthNote("ttl");
+		authSession.removeAuthNote("mobile_number");
+		authSession.addRequiredAction(PhoneNumberRequiredAction.PROVIDER_ID);
+		logger.infof("SMS enrollment: user %s requested a phone number change", context.getUser().getUsername());
+		context.success();
+	}
+
+	private Response createCodeForm(RequiredActionContext context, String error) {
+		var form = context.form()
+			.setAttribute("realm", context.getRealm())
+			.setAttribute("smsEnrollment", true)
+			.setAttribute("phoneNumber", context.getAuthenticationSession().getAuthNote("mobile_number"));
+		if (error != null) {
+			form = form.setError(error);
+		}
+		return form.createForm(SmsAuthenticator.TPL_CODE);
+	}
+
 	private void handlePhoneToAttribute(RequiredActionContext context, String mobileNumber) {
 		AuthenticatorConfigModel config = context.getRealm().getAuthenticatorConfigByAlias("sms-2fa");
 		if (config == null) {
@@ -137,12 +163,7 @@ public class PhoneValidationRequiredAction implements RequiredActionProvider, Cr
 	}
 
 	private void handleInvalidSmsCode(RequiredActionContext context) {
-		Response challenge = context
-			.form()
-			.setAttribute("realm", context.getRealm())
-			.setError("smsAuthCodeInvalid")
-			.createForm(SmsAuthenticator.TPL_CODE);
-		context.challenge(challenge);
+		context.challenge(createCodeForm(context, "smsAuthCodeInvalid"));
 	}
 
 	@Override

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_ca.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_ca.properties
@@ -4,6 +4,7 @@ smsAuthTitle=Codi SMS
 smsAuthLabel=Codi SMS
 smsAuthInstruction=Introduïu el codi que s’ha enviat al vostre dispositiu.
 smsAuthInstructionWithPhone=Introduïu el codi que hem enviat a {0}.
+smsAuthChangeNumber=Canvia el número de telèfon
 
 smsAuthSmsNotSent=No s’ha pogut enviar el SMS, perquè {0}
 smsAuthCodeExpired=El codi SMS ha caducat.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_de.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_de.properties
@@ -4,6 +4,7 @@ smsAuthTitle=SMS Code
 smsAuthLabel=SMS Code
 smsAuthInstruction=Geben Sie den SMS Code ein, den wir an Ihr Gerät gesendet haben.
 smsAuthInstructionWithPhone=Geben Sie den Code ein, den wir an {0} gesendet haben.
+smsAuthChangeNumber=Telefonnummer ändern
 
 smsAuthSmsNotSent=Die SMS konnte nicht gesendet werden. Grund: {0}
 smsAuthCodeExpired=Der SMS Code ist abgelaufen.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_en.properties
@@ -4,6 +4,7 @@ smsAuthTitle=SMS Code
 smsAuthLabel=SMS Code
 smsAuthInstruction=Enter the code we sent to your device.
 smsAuthInstructionWithPhone=Enter the code we sent to {0}.
+smsAuthChangeNumber=Change phone number
 
 smsAuthSmsNotSent=The SMS could not be sent, because of {0}
 smsAuthCodeExpired=The SMS code has expired.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_es.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_es.properties
@@ -4,6 +4,7 @@ smsAuthTitle=Código SMS
 smsAuthLabel=Código SMS
 smsAuthInstruction=Introduzca el código que se ha enviado a su dispositivo.
 smsAuthInstructionWithPhone=Introduzca el código que hemos enviado a {0}.
+smsAuthChangeNumber=Cambiar número de teléfono
 
 smsAuthSmsNotSent=El SMS no pudo ser enviado, porque {0}
 smsAuthCodeExpired=El código SMS ha caducado.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_fi.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_fi.properties
@@ -4,6 +4,7 @@ smsAuthTitle=Vahvistuskoodi
 smsAuthLabel=Vahvistuskoodi
 smsAuthInstruction=Syötä koodi, jonka lähetimme laitteeseesi.
 smsAuthInstructionWithPhone=Syötä koodi, jonka lähetimme numeroon {0}.
+smsAuthChangeNumber=Vaihda puhelinnumero
 
 smsAuthSmsNotSent=Tekstiviestiä ei voitu lähettää, koska {0}
 smsAuthCodeExpired=Vahvistuskoodi on vanhentunut.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_fr.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_fr.properties
@@ -4,6 +4,7 @@ smsAuthTitle=Code de vérification par SMS
 smsAuthLabel=Code de vérification
 smsAuthInstruction=Entrez le code que nous avons envoyé à votre appareil.
 smsAuthInstructionWithPhone=Entrez le code que nous avons envoyé au {0}.
+smsAuthChangeNumber=Changer de numéro
 
 smsAuthSmsNotSent=Le SMS n'a pas pu être envoyé en raison de {0}
 smsAuthCodeExpired=Le code de vérification a expiré.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_it.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_it.properties
@@ -4,6 +4,7 @@ smsAuthTitle=Codice SMS
 smsAuthLabel=Codice SMS
 smsAuthInstruction=Inserisci il codice che abbiamo inviato al tuo dispositivo.
 smsAuthInstructionWithPhone=Inserisci il codice che abbiamo inviato a {0}.
+smsAuthChangeNumber=Cambia numero di telefono
 
 smsAuthSmsNotSent=L''SMS non può essere inviato, a causa di {0}
 smsAuthCodeExpired=Il codice SMS è scaduto.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_nl.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_nl.properties
@@ -4,6 +4,7 @@ smsAuthTitle=SMS-code
 smsAuthLabel=SMS-code
 smsAuthInstruction=Voer de code in die we naar uw apparaat hebben gestuurd.
 smsAuthInstructionWithPhone=Voer de code in die we naar {0} hebben gestuurd.
+smsAuthChangeNumber=Telefoonnummer wijzigen
 
 smsAuthSmsNotSent=De SMS kon niet worden verzonden vanwege {0}
 smsAuthCodeExpired=De SMS-code is verlopen.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_pl.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_pl.properties
@@ -4,6 +4,7 @@ smsAuthTitle=Kod SMS
 smsAuthLabel=Kod SMS
 smsAuthInstruction=Wpisz kod SMS, który wysłaliśmy na twoje urządzenie.
 smsAuthInstructionWithPhone=Wpisz kod SMS, który wysłaliśmy na numer {0}.
+smsAuthChangeNumber=Zmień numer telefonu
 
 smsAuthSmsNotSent=Nie udało się wysłać SMS-a. Powód: {0}
 smsAuthCodeExpired=Kod SMS wygasł.

--- a/sms-authenticator/src/main/resources/theme-resources/messages/messages_ru.properties
+++ b/sms-authenticator/src/main/resources/theme-resources/messages/messages_ru.properties
@@ -4,6 +4,7 @@ smsAuthTitle=SMS-код
 smsAuthLabel=SMS-код
 smsAuthInstruction=Введите код, который мы отправили на ваше устройство.
 smsAuthInstructionWithPhone=Введите код, который мы отправили на номер {0}.
+smsAuthChangeNumber=Изменить номер телефона
 
 smsAuthSmsNotSent=Не удалось отправить SMS. Причина: {0}
 smsAuthCodeExpired=Срок действия SMS-кода истёк.

--- a/sms-authenticator/src/main/resources/theme-resources/templates/login-sms.ftl
+++ b/sms-authenticator/src/main/resources/theme-resources/templates/login-sms.ftl
@@ -12,17 +12,32 @@
 					<input type="number" min="0" inputmode="numeric" pattern="[0-9]*" id="code" name="code" class="${properties.kcInputClass!}" autocomplete="off" autofocus />
 				</div>
 			</div>
+			<#if smsEnrollment??>
+			<div class="pf-v5-c-form__group pf-m-action">
+				<div class="pf-v5-c-form__actions" style="display:flex; gap:0.5rem; width:100%">
+					<button type="submit" class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonLargeClass!}" name="sms-action" value="change-number" style="flex:1 1 0; min-width:0">${msg("smsAuthChangeNumber")}</button>
+					<button type="submit" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}" name="login" style="flex:1 1 0; min-width:0">${msg("doSubmit")}</button>
+				</div>
+			</div>
 			<div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
 				<div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
 					<div class="${properties.kcFormOptionsWrapperClass!}">
 						<span><a href="/realms/${realm.name}/account">${msg("backToApplication")?no_esc}</a></span>
 					</div>
 				</div>
-
+			</div>
+			<#else>
+			<div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
+				<div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
+					<div class="${properties.kcFormOptionsWrapperClass!}">
+						<span><a href="/realms/${realm.name}/account">${msg("backToApplication")?no_esc}</a></span>
+					</div>
+				</div>
 				<div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
 					<input name="login" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doSubmit")}"/>
 				</div>
 			</div>
+			</#if>
 		</form>
 	<#elseif section = "info" >
 		<#if phoneNumber?? && phoneNumber?has_content>

--- a/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorFlowTest.java
+++ b/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/SmsAuthenticatorFlowTest.java
@@ -42,6 +42,7 @@ import java.util.regex.Pattern;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -226,6 +227,49 @@ public class SmsAuthenticatorFlowTest {
 		} finally {
 			SmsTestSupport.updateSmsExecutionConfig(managedRealm, Map.of("ttl", "300"));
 		}
+	}
+
+	@Test
+	public void changeNumberFromCodeStepRestartsPhoneEntry() throws Exception {
+		oauth.openLoginForm();
+		loginPage.fillLogin(user.getUsername(), user.getPassword());
+		loginPage.submit();
+
+		phoneNumberSetupPage.assertCurrent();
+		phoneNumberSetupPage.enterPhoneNumber("+491234567");
+		phoneNumberSetupPage.submit();
+
+		smsCodePage.assertCurrent();
+		assertTrue(smsCodePage.hasChangeNumber());
+		smsRequestBodies.clear();
+		smsCodePage.changeNumber();
+
+		phoneNumberSetupPage.assertCurrent();
+		phoneNumberSetupPage.enterPhoneNumber("+499876543");
+		phoneNumberSetupPage.submit();
+
+		smsCodePage.assertCurrent();
+		smsCodePage.enterCode(awaitSmsCode());
+		smsCodePage.submit();
+
+		boolean hasMobileNumberCredential = managedRealm.admin().users().get(user.getId())
+			.credentials()
+			.stream()
+			.anyMatch(credential -> "mobile-number".equals(credential.getType()));
+		assertTrue(hasMobileNumberCredential, "Expected a mobile-number credential after changing the phone number");
+	}
+
+	@Test
+	public void loginSmsChallengeDoesNotShowEnrollmentActions() throws Exception {
+		registerPhoneNumber();
+		logout();
+
+		oauth.openLoginForm();
+		loginPage.fillLogin(user.getUsername(), user.getPassword());
+		loginPage.submit();
+
+		smsCodePage.assertCurrent();
+		assertFalse(smsCodePage.hasChangeNumber(), "Change number belongs to enrollment, not login 2FA");
 	}
 
 	private void registerPhoneNumber() throws InterruptedException {

--- a/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/SmsCodePage.java
+++ b/sms-authenticator/src/test/java/netzbegruenung/keycloak/authenticator/SmsCodePage.java
@@ -2,6 +2,7 @@ package netzbegruenung.keycloak.authenticator;
 
 import org.keycloak.testframework.ui.page.AbstractLoginPage;
 import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
@@ -15,8 +16,11 @@ public class SmsCodePage extends AbstractLoginPage {
 	@FindBy(id = "code")
 	private WebElement codeInput;
 
-	@FindBy(css = "#kc-sms-code-login-form input[type='submit']")
+	@FindBy(css = "#kc-sms-code-login-form [name='login']")
 	private WebElement submitButton;
+
+	@FindBy(css = "button[name='sms-action'][value='change-number']")
+	private WebElement changeNumberButton;
 
 	public SmsCodePage(ManagedWebDriver driver) {
 		super(driver);
@@ -34,5 +38,13 @@ public class SmsCodePage extends AbstractLoginPage {
 
 	public void submit() {
 		submitButton.click();
+	}
+
+	public void changeNumber() {
+		changeNumberButton.click();
+	}
+
+	public boolean hasChangeNumber() {
+		return !driver.driver().findElements(By.cssSelector("button[name='sms-action'][value='change-number']")).isEmpty();
 	}
 }


### PR DESCRIPTION
Hello @melegiul,

#375 already keeps the phone-number required action on the authentication session during SMS validation, so users can correct a typo or pick another number.
This PR exposes that as an in-flow Change phone number` button on the enrollment code form, without leaving the flow.

<img width="609" height="556" alt="image" src="https://github.com/user-attachments/assets/09422618-4590-48d5-931d-a24f4b2d64d4" />

Happy to adjust the UI if you'd like something different.
Thomas