### PR TITLE
feat(app): allow same-user overwrite of app-authenticator device registration

### DIFF
--- a/app-authenticator/src/main/java/netzbegruenung/keycloak/app/actiontoken/AppSetupActionTokenHandler.java
+++ b/app-authenticator/src/main/java/netzbegruenung/keycloak/app/actiontoken/AppSetupActionTokenHandler.java
@@ -2,11 +2,13 @@ package netzbegruenung.keycloak.app.actiontoken;
 
 import netzbegruenung.keycloak.app.AppCredentialProviderFactory;
 import netzbegruenung.keycloak.app.credentials.AppCredentialModel;
+import netzbegruenung.keycloak.app.jpa.AppAuthCredentialIndex;
 import netzbegruenung.keycloak.app.rest.AppCredentialService;
 import netzbegruenung.keycloak.app.rest.StatusResourceProvider;
 import org.keycloak.authentication.actiontoken.AbstractActionTokenHandler;
 import org.keycloak.authentication.actiontoken.ActionTokenContext;
 import org.keycloak.credential.CredentialProvider;
+import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
 import org.keycloak.models.ModelDuplicateException;
@@ -50,7 +52,7 @@ public class AppSetupActionTokenHandler extends AbstractActionTokenHandler<AppSe
 
 		UserModel user = tokenContext.getAuthenticationSession().getAuthenticatedUser();
 		AppCredentialService appCredentialService = new AppCredentialService(tokenContext.getSession());
-		boolean deviceIdTaken = appCredentialService.isDeviceIdRegistered(tokenContext.getRealm(), deviceId);
+		AppAuthCredentialIndex existingIndex = appCredentialService.findByRealmAndDeviceId(tokenContext.getRealm(), deviceId);
 
 		AuthenticationSessionModel authSession = ActionTokenUtil.getOriginalAuthSession(
 			tokenContext.getSession(),
@@ -62,7 +64,7 @@ public class AppSetupActionTokenHandler extends AbstractActionTokenHandler<AppSe
 			return Response.status(Response.Status.FORBIDDEN).build();
 		}
 
-		if (deviceIdTaken) {
+		if (existingIndex != null && !existingIndex.getUser().getId().equals(user.getId())) {
 			authSession.setAuthNote("duplicateDeviceId", Boolean.toString(true));
 			authSession.setAuthNote(StatusResourceProvider.READY, Boolean.toString(true));
 			return Response.status(400).build();
@@ -72,6 +74,16 @@ public class AppSetupActionTokenHandler extends AbstractActionTokenHandler<AppSe
 			CredentialProvider.class,
 			AppCredentialProviderFactory.PROVIDER_ID
 		);
+
+		// Re-registering the same device_id the user already owns (e.g. reinstalling the app):
+		// replace the old credential rather than rejecting. The old index row is removed by the
+		// CREDENTIAL_ID -> CREDENTIAL onDelete=CASCADE FK (app-credential-index-changelog.xml), so
+		// no separate index cleanup is needed here.
+		boolean isOverwrite = existingIndex != null;
+		if (isOverwrite) {
+			appCredentialProvider.deleteCredential(tokenContext.getRealm(), user, existingIndex.getCredentialId());
+		}
+
 		try {
 			appCredentialProvider.createCredential(
 				tokenContext.getRealm(),
@@ -84,6 +96,15 @@ public class AppSetupActionTokenHandler extends AbstractActionTokenHandler<AppSe
 			authSession.setAuthNote("duplicateDeviceId", Boolean.toString(true));
 			authSession.setAuthNote(StatusResourceProvider.READY, Boolean.toString(true));
 			return Response.status(400).build();
+		}
+
+		if (isOverwrite) {
+			tokenContext.getEvent().clone().event(EventType.UPDATE_CREDENTIAL)
+				.user(user)
+				.detail(Details.CREDENTIAL_TYPE, AppCredentialModel.TYPE)
+				.detail("device_id", deviceId)
+				.detail("replaced_credential_id", existingIndex.getCredentialId())
+				.success();
 		}
 
 		authSession.setAuthNote("appSetupSuccessful", Boolean.toString(true));

--- a/app-authenticator/src/main/java/netzbegruenung/keycloak/app/rest/AppCredentialService.java
+++ b/app-authenticator/src/main/java/netzbegruenung/keycloak/app/rest/AppCredentialService.java
@@ -85,22 +85,23 @@ public class AppCredentialService {
 	}
 
 	/**
-	 * Realm-wide check, required because (realm_id, device_id) is a DB-level unique
+	 * Realm-wide lookup, required because (realm_id, device_id) is a DB-level unique
 	 * constraint on AppAuthCredentialIndex - registration must pre-check across all users,
-	 * not just the requesting user's own credentials. Reuses findByRealmAndDeviceId rather
-	 * than a separate count query: the unique constraint guarantees at most one match, so
-	 * NoResultException already tells us everything a count would.
+	 * not just the requesting user's own credentials.
 	 */
-	public boolean isDeviceIdRegistered(RealmModel realm, String deviceId) {
+	public AppAuthCredentialIndex findByRealmAndDeviceId(RealmModel realm, String deviceId) {
 		try {
-			em.createNamedQuery("AppAuthCredentialIndex.findByRealmAndDeviceId", AppAuthCredentialIndex.class)
+			return em.createNamedQuery("AppAuthCredentialIndex.findByRealmAndDeviceId", AppAuthCredentialIndex.class)
 				.setParameter("realm", em.getReference(RealmEntity.class, realm.getId()))
 				.setParameter("deviceId", deviceId)
 				.getSingleResult();
-			return true;
 		} catch (NoResultException e) {
-			return false;
+			return null;
 		}
+	}
+
+	public boolean isDeviceIdRegistered(RealmModel realm, String deviceId) {
+		return findByRealmAndDeviceId(realm, deviceId) != null;
 	}
 
 	/**

--- a/app-authenticator/src/test/java/netzbegruenung/keycloak/app/AppAuthSetupPage.java
+++ b/app-authenticator/src/test/java/netzbegruenung/keycloak/app/AppAuthSetupPage.java
@@ -2,6 +2,7 @@ package netzbegruenung.keycloak.app;
 
 import org.keycloak.testframework.ui.page.AbstractLoginPage;
 import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
@@ -32,7 +33,15 @@ public class AppAuthSetupPage extends AbstractLoginPage {
 		return actionTokenInput.getAttribute("value");
 	}
 
+	/**
+	 * Submits via JS rather than {@code WebElement.submit()}: the latter follows the WebDriver
+	 * spec's "activate the form's default submit button" semantics, which - when this action was
+	 * triggered as an application-initiated action (kc_action) - is the template's "cancel-aia"
+	 * button (the only other one is type="button", not a submit control), incorrectly cancelling
+	 * the action instead of completing it. A JS-level submit(), like the page's own SSE-triggered
+	 * auto-submit, never activates any button.
+	 */
 	public void submit() {
-		form.submit();
+		((JavascriptExecutor) driver.driver()).executeScript("arguments[0].submit();", form);
 	}
 }

--- a/app-authenticator/src/test/java/netzbegruenung/keycloak/app/AppAuthenticatorFlowTest.java
+++ b/app-authenticator/src/test/java/netzbegruenung/keycloak/app/AppAuthenticatorFlowTest.java
@@ -35,6 +35,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -50,8 +51,11 @@ public class AppAuthenticatorFlowTest {
 	@InjectRealm
 	ManagedRealm managedRealm;
 
-	@InjectUser(config = AppUserConfig.class, lifecycle = LifeCycle.METHOD)
+	@InjectUser(ref = "user", config = AppUserConfig.class, lifecycle = LifeCycle.METHOD)
 	ManagedUser user;
+
+	@InjectUser(ref = "secondUser", config = SecondAppUserConfig.class, lifecycle = LifeCycle.METHOD)
+	ManagedUser secondUser;
 
 	@InjectWebDriver
 	ManagedWebDriver driver;
@@ -149,15 +153,111 @@ public class AppAuthenticatorFlowTest {
 		appLoginPage.assertCurrent();
 	}
 
-	private AppDeviceSimulator registerDevice() throws Exception {
+	@Test
+	public void reregisteringSameDeviceIdReplacesOwnCredential() throws Exception {
+		AppDeviceSimulator firstDevice = registerDevice();
+		String firstCredentialId = getAppCredentialId(user);
+		logout();
+		events.clear();
+
+		// The user already has the app credential configured, so "Conditional 2FA" challenges
+		// with it first (proving continued possession of the account) before the
+		// application-initiated "app-register" action (kc_action - the same AIA mechanism the
+		// account console uses) is allowed to run.
+		oauth.loginForm().kcAction(AppRequiredAction.PROVIDER_ID).open();
+		loginPage.fillLogin(user.getUsername(), user.getPassword());
+		loginPage.submit();
+
+		appLoginPage.assertCurrent();
+		ChallengeDto loginChallenge = awaitChallenge(firstDevice);
+		assertEquals(204, firstDevice.respond(loginChallenge, true));
+		appLoginPage.submit();
+
+		appAuthSetupPage.assertCurrent();
+		String actionTokenUrl = appAuthSetupPage.getActionTokenUrl();
+
+		// Same device_id as firstDevice (simulating a reinstall), fresh key pair.
+		AppDeviceSimulator secondDevice = new AppDeviceSimulator(firstDevice.deviceId());
+		assertEquals(201, secondDevice.register(actionTokenUrl), "Expected overwrite registration to succeed");
+
+		appAuthSetupPage.submit();
+
+		EventAssertion.assertSuccess(events.poll())
+			.type(EventType.UPDATE_CREDENTIAL)
+			.userId(user.getId())
+			.details(Details.CREDENTIAL_TYPE, AppCredentialModel.TYPE);
+
+		EventAssertion.assertSuccess(events.poll())
+			.type(EventType.CUSTOM_REQUIRED_ACTION)
+			.userId(user.getId());
+
+		EventAssertion.assertSuccess(events.poll())
+			.type(EventType.LOGIN)
+			.userId(user.getId())
+			.details(Details.USERNAME, user.getUsername());
+
+		var appCredentials = managedRealm.admin().users().get(user.getId())
+			.credentials().stream()
+			.filter(credential -> AppCredentialModel.TYPE.equals(credential.getType()))
+			.toList();
+		assertEquals(1, appCredentials.size(), "Expected exactly one APP_CREDENTIAL after overwrite");
+		assertNotEquals(firstCredentialId, appCredentials.get(0).getId(), "Expected a new credential id after overwrite");
+
+		// The new credential is actually usable for login, not just present.
+		logout();
+		events.clear();
+
 		oauth.openLoginForm();
 		loginPage.fillLogin(user.getUsername(), user.getPassword());
+		loginPage.submit();
+
+		appLoginPage.assertCurrent();
+
+		ChallengeDto challenge = awaitChallenge(secondDevice);
+		assertEquals(204, secondDevice.respond(challenge, true));
+
+		appLoginPage.submit();
+
+		EventAssertion.assertSuccess(events.poll())
+			.type(EventType.LOGIN)
+			.userId(user.getId())
+			.details(Details.USERNAME, user.getUsername());
+	}
+
+	@Test
+	public void differentUserCannotClaimAnotherUsersDeviceId() throws Exception {
+		AppDeviceSimulator device = registerDevice();
+		logout();
+		events.clear();
+
+		oauth.openLoginForm();
+		loginPage.fillLogin(secondUser.getUsername(), secondUser.getPassword());
 		loginPage.submit();
 
 		appAuthSetupPage.assertCurrent();
 		String actionTokenUrl = appAuthSetupPage.getActionTokenUrl();
 
-		AppDeviceSimulator device = new AppDeviceSimulator();
+		AppDeviceSimulator conflictingDevice = new AppDeviceSimulator(device.deviceId());
+		assertEquals(400, conflictingDevice.register(actionTokenUrl), "Expected duplicate device_id registration to be rejected");
+
+		boolean secondUserHasAppCredential = managedRealm.admin().users().get(secondUser.getId())
+			.credentials().stream()
+			.anyMatch(credential -> AppCredentialModel.TYPE.equals(credential.getType()));
+		assertFalse(secondUserHasAppCredential, "Expected no APP_CREDENTIAL for the second user after a rejected duplicate device_id");
+	}
+
+	private AppDeviceSimulator registerDevice() throws Exception {
+		oauth.openLoginForm();
+		loginPage.fillLogin(user.getUsername(), user.getPassword());
+		loginPage.submit();
+
+		return completeSetup(new AppDeviceSimulator());
+	}
+
+	private AppDeviceSimulator completeSetup(AppDeviceSimulator device) throws Exception {
+		appAuthSetupPage.assertCurrent();
+		String actionTokenUrl = appAuthSetupPage.getActionTokenUrl();
+
 		assertEquals(201, device.register(actionTokenUrl), "Expected device registration to succeed");
 
 		appAuthSetupPage.submit();
@@ -175,6 +275,15 @@ public class AppAuthenticatorFlowTest {
 			.details(Details.USERNAME, user.getUsername());
 
 		return device;
+	}
+
+	private String getAppCredentialId(ManagedUser managedUser) {
+		return managedRealm.admin().users().get(managedUser.getId())
+			.credentials().stream()
+			.filter(credential -> AppCredentialModel.TYPE.equals(credential.getType()))
+			.findFirst()
+			.orElseThrow(() -> new IllegalStateException("Expected an APP_CREDENTIAL for user " + managedUser.getId()))
+			.getId();
 	}
 
 	private ChallengeDto awaitChallenge(AppDeviceSimulator device) throws Exception {
@@ -201,6 +310,18 @@ public class AppAuthenticatorFlowTest {
 				.password("password")
 				.name("App", "Flow")
 				.email("app-flow@example.com")
+				.emailVerified(true)
+				.requiredActions(AppRequiredAction.PROVIDER_ID);
+		}
+	}
+
+	public static class SecondAppUserConfig implements UserConfig {
+		@Override
+		public UserBuilder configure(UserBuilder user) {
+			return user.username("app-flow-user-2")
+				.password("password")
+				.name("App", "FlowTwo")
+				.email("app-flow-2@example.com")
 				.emailVerified(true)
 				.requiredActions(AppRequiredAction.PROVIDER_ID);
 		}

--- a/app-authenticator/src/test/java/netzbegruenung/keycloak/app/AppDeviceSimulator.java
+++ b/app-authenticator/src/test/java/netzbegruenung/keycloak/app/AppDeviceSimulator.java
@@ -36,8 +36,17 @@ final class AppDeviceSimulator {
 	private final String deviceId;
 
 	AppDeviceSimulator() throws NoSuchAlgorithmException {
+		this(UUID.randomUUID().toString());
+	}
+
+	/**
+	 * Simulates reinstalling the app on a device whose device_id doesn't change: a fresh key
+	 * pair (a real reinstall wouldn't retain the old one), same device_id as an earlier
+	 * simulator instance.
+	 */
+	AppDeviceSimulator(String deviceId) throws NoSuchAlgorithmException {
 		this.keyPair = KeyPairGenerator.getInstance(KEY_ALGORITHM).generateKeyPair();
-		this.deviceId = UUID.randomUUID().toString();
+		this.deviceId = deviceId;
 	}
 
 	String deviceId() {


### PR DESCRIPTION
## Summary
- `device_id` re-registration for app-authenticator used to always be rejected as a duplicate, even when the existing registration belongs to the same user (e.g. reinstalling the app on a device whose device_id doesn't change).
- `AppSetupActionTokenHandler` now checks ownership of the conflicting `device_id`: a different owner is still rejected exactly as before, but the same owner gets their old credential replaced (delete + recreate) and an `UPDATE_CREDENTIAL` audit event emitted. No extra index cleanup needed — `AppAuthCredentialIndex.credential_id` already cascades on delete from Keycloak's `CREDENTIAL` table.
- Fixed two test-harness bugs found while adding coverage: `@InjectUser` needs distinct `ref()` values to inject two separate users in one test class, and `AppAuthSetupPage.submit()` needed to switch from `WebElement.submit()` (which activates the form's default submit button — the AIA "cancel-aia" button when present) to a JS-level `submit()`, matching what the real page's own SSE-triggered auto-submit does.

## Test plan
- [x] `reregisteringSameDeviceIdReplacesOwnCredential`: same user re-registers the same `device_id` via the AIA `kc_action` flow (after passing the existing 2FA challenge) → old credential replaced, exactly one `APP_CREDENTIAL` remains with a new id, `UPDATE_CREDENTIAL` event observed, new credential verified usable for login.
- [x] `differentUserCannotClaimAnotherUsersDeviceId`: regression test confirming a different user is still rejected.
- [x] Full `app-authenticator` module test suite passes (19 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)